### PR TITLE
Capture core dump for z/os in test compilation

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,5 +70,15 @@ getdependency:
 #######################################
 # compile all tests under $(TEST_ROOT)
 #######################################
+COMPILATION_LOG=$(TESTOUTPUT)$(D)compile$(D)compilation.log
+
+MOVE_TDUMP_PERL=perl scripts$(D)moveDmp.pl --compileLogPath=$(Q)$(COMPILATION_LOG)$(Q)
+MOVE_TDUMP=if [ -z $$(tail -n 1 $(COMPILATION_LOG) | grep 0) ]; then $(MOVE_TDUMP_PERL); $(RM) $(Q)$(COMPILATION_LOG)$(Q); false; else $(RM) $(Q)$(COMPILATION_LOG)$(Q); fi
+COMPILE_CMD=ant -f scripts$(D)build_test.xml -DTEST_ROOT=$(TEST_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJDK_VERSION=$(JDK_VERSION) -DJDK_IMPL=$(JDK_IMPL) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DRESOURCES_DIR=${RESOURCES_DIR} -DPLATFORM=${PLATFORM} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJVM_VERSION=$(JVM_VERSION) -DLIB_DIR=$(LIB_DIR)
 compile: getdependency
-	ant -f scripts$(D)build_test.xml -DTEST_ROOT=$(TEST_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJDK_VERSION=$(JDK_VERSION) -DJDK_IMPL=$(JDK_IMPL) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DRESOURCES_DIR=${RESOURCES_DIR} -DPLATFORM=${PLATFORM} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJVM_VERSION=$(JVM_VERSION) -DLIB_DIR=$(LIB_DIR)
+ifneq (,$(findstring zos,$(SPEC)))
+	$(MKTREE) $(TESTOUTPUT)$(D)compile;
+	($(COMPILE_CMD) 2>&1; echo $$? ) | tee $(Q)$(COMPILATION_LOG)$(Q); $(MOVE_TDUMP)
+else
+	$(COMPILE_CMD)
+endif


### PR DESCRIPTION
- Added moveTDUMP to move core dump to
REPORTDIR/compile

Signed-off-by: Jenny Chen <Jenny.Chen@ibm.com>