### PR TITLE
Change RESOURCES_DIR path

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -161,7 +161,7 @@ JAVA_COMMAND:=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)java$(Q)
 #######################################
 LIB_DIR=$(JVM_TEST_ROOT)$(D)TestConfig$(D)lib
 TESTNG=$(LIB_DIR)$(D)testng.jar$(P)$(LIB_DIR)$(D)jcommander.jar
-RESOURCES_DIR=$(JVM_TEST_ROOT)$(D)TKG$(D)resources
+RESOURCES_DIR=$(JVM_TEST_ROOT)$(D)TestConfig$(D)resources
 
 #######################################
 # cmdlinetester jars


### PR DESCRIPTION
- use TestConfig as it contains testng log property file

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>