### PR TITLE
Update ARCH and BITS parser

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -136,9 +136,13 @@ ARCH_INFO:=$(word 2,$(WORD_LIST))
 
 BITS=bits.32
 ARCH=arch.$(ARCH_INFO)
-ifneq (,$(findstring -64,$(ARCH_INFO)))
+ifneq (,$(findstring 64,$(ARCH_INFO)))
 	BITS=bits.64
-	ARCH:=arch.$(subst -64,,$(ARCH_INFO))
+	ifneq (,$(findstring -64,$(ARCH_INFO)))
+		ARCH:=arch.$(subst -64,,$(ARCH_INFO))
+	else
+		ARCH:=arch.$(subst 64,,$(ARCH_INFO))
+	endif
 else
 	ifneq (,$(findstring 390,$(ARCH_INFO)))
 		BITS=bits.31


### PR DESCRIPTION
Update ARCH and BITS parser to work with SPEC linux_aarch64. So
JVM_OPTION could be set properly. 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>