### PR TITLE
Fix failed and test target

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,7 +30,6 @@ ifndef TEST_ROOT
 	TEST_ROOT := $(shell pwd)$(D)..
 endif
 
-
 #######################################
 # run test
 #######################################
@@ -38,9 +37,13 @@ _TESTTARGET = $(firstword $(MAKECMDGOALS))
 TESTTARGET = $(patsubst _%,%,$(_TESTTARGET))
 ifneq (compile, $(_TESTTARGET))
 ifneq (clean, $(_TESTTARGET))
+ifneq (test, $(_TESTTARGET))
+ifneq (_failed, $(_TESTTARGET))
 $(_TESTTARGET):
 	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) TESTTARGET=$(TESTTARGET)
 	$(MAKE) -f runtest.mk $(_TESTTARGET)
+endif
+endif
 endif
 endif
 
@@ -57,6 +60,27 @@ else
 	@echo "AUTO_DETECT is set to false"
 endif
 	$(MAKE) -f compile.mk compile
+
+#######################################
+# compile and run all tests
+#######################################
+test: compile _all
+	@$(ECHO) "All Tests Completed"
+
+.PHONY: test
+
+.NOTPARALLEL: test
+
+#######################################
+# run failed tests
+#######################################
+_failed:
+	@$(MAKE) -f failedtargets.mk _failed
+
+.PHONY: _failed
+
+.NOTPARALLEL: _failed
+
 
 #######################################
 # clean

--- a/runtest.mk
+++ b/runtest.mk
@@ -27,24 +27,3 @@ ifndef TEST_ROOT
 endif
 
 include settings.mk
-
-include count.mk
-
-runtest:
-	@$(MAKE) -C $(TEST_ROOT) -f autoGen.mk _all
-
-.PHONY: runtest
-
-test: compile runtest
-	@$(ECHO) "All Tests Completed"
-
-.PHONY: test
-
-.NOTPARALLEL: test
-
-failed:
-	@$(MAKE) -f failedtargets.mk failed
-
-.PHONY: failed
-
-.NOTPARALLEL: failed

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -267,6 +267,7 @@ sub failureMkGen {
 					. "ifndef TEST_ROOT\n"
 					. "\tTEST_ROOT := \$(shell pwd)\$(D)..\n"
 					. "endif\n\n"
+					. "include settings.mk\n\n"
 					. "failed:\n";
 		foreach my $target (@$failureTargets) {
 			print $fhOut '	@$(MAKE) -C $(TEST_ROOT) -f autoGen.mk ' . $target . "\n";


### PR DESCRIPTION
- move failed and test target
- remove runtest target
- include settings.mk in failedtargets.mk

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>