### PR TITLE
Count tests skipped at runtime as passing

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -83,7 +83,7 @@ ifndef JVM_VERSION
 
 ifeq (hotspot, $(JDK_IMPL))
 	JVM_VERSION = $(OPENJDK_VERSION)
-else 
+else
 	JVM_VERSION = $(OPENJDK_VERSION)-$(JDK_IMPL)
 endif
 
@@ -94,7 +94,7 @@ ifneq (,$(findstring win,$(SPEC)))
 P=;
 D=\\
 EXECUTABLE_SUFFIX=.exe
-RUN_SCRIPT="cmd /c" 
+RUN_SCRIPT="cmd /c"
 RUN_SCRIPT_STRING=$(RUN_SCRIPT)
 SCRIPT_SUFFIX=.bat
 PROPS_DIR=props_win
@@ -194,10 +194,12 @@ KEEP_REPORTDIR?=true
 ifeq ($(KEEP_REPORTDIR), false)
 	RM_REPORTDIR=$(RM) -r $(REPORTDIR);
 endif
-ifeq ($(TEST_ITERATIONS), 1) 
-	TEST_STATUS=if [ $$? -eq 0 ] ; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); $(ECHO) $(Q)$(Q); $(CD) $(TEST_ROOT); $(RM_REPORTDIR) else $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED$(Q); $(ECHO) $(Q)$(Q); fi
+# TestNG returns a specific exit code if all tests are skipped at runtime; for that case count the test as passing.
+TESTNG_ALL_SKIPPED_EXIT_CODE=2
+ifeq ($(TEST_ITERATIONS), 1)
+	TEST_STATUS=if [ $$? -eq 0 -o $$? -eq $(TESTNG_ALL_SKIPPED_EXIT_CODE) ]; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); $(ECHO) $(Q)$(Q); $(CD) $(TEST_ROOT); $(RM_REPORTDIR) else $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED$(Q); $(ECHO) $(Q)$(Q); fi
 else
-	TEST_STATUS=if [ $$? -eq 0 ] ; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED(ITER_$$itercnt)$(Q); $(ECHO) $(Q)$(Q); $(CD) $(TEST_ROOT); $(RM_REPORTDIR) if [ $$itercnt -eq $(TEST_ITERATIONS) ] ; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); $(ECHO) $(Q)$(Q); fi else $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED(ITER_$$itercnt)$(Q); $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED$(Q); $(ECHO) $(Q)$(Q); exit 1; fi
+	TEST_STATUS=if [ $$? -eq 0 -o $$? -eq $(TESTNG_ALL_SKIPPED_EXIT_CODE) ]; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED(ITER_$$itercnt)$(Q); $(ECHO) $(Q)$(Q); $(CD) $(TEST_ROOT); $(RM_REPORTDIR) if [ $$itercnt -eq $(TEST_ITERATIONS) ] ; then $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); $(ECHO) $(Q)$(Q); fi else $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED(ITER_$$itercnt)$(Q); $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$(Q); $(ECHO) $(Q)$@$(Q)$(Q)_FAILED$(Q); $(ECHO) $(Q)$(Q); exit 1; fi
 endif
 
 ifneq ($(DEBUG),)


### PR DESCRIPTION
TestNG returns a specific exit code if all tests are skipped at
runtime. For such cases we should count the test as passing
because (presumably) the test knows what it's doing.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>