### PR TITLE
z/OS needs jdk/lib in ADD_JVM_LIB_DIR_TO_LIBPATH

### DIFF
--- a/openj9Settings.mk
+++ b/openj9Settings.mk
@@ -95,6 +95,7 @@ else
 		else
 			VM_SUBDIR_PATH=$(TEST_JRE_LIB_DIR)$(D)$(ARCH_DIR)$(D)$(VM_SUBDIR)
 			J9VM_PATH=$(TEST_JRE_LIB_DIR)$(D)$(ARCH_DIR)$(D)j9vm
+			LIB_PATH=$(TEST_JRE_LIB_DIR)$(D)$(ARCH_DIR)
 		endif
 	else
 		ifneq (,$(findstring win,$(SPEC))) 
@@ -103,6 +104,7 @@ else
 		else
 			VM_SUBDIR_PATH=$(TEST_JDK_LIB_DIR)$(D)$(VM_SUBDIR)
 			J9VM_PATH=$(TEST_JDK_LIB_DIR)$(D)j9vm
+			LIB_PATH=$(TEST_JDK_LIB_DIR)
 		endif
 	endif
 
@@ -124,7 +126,7 @@ else
 	else ifneq (,$(findstring aix,$(SPEC)))
 		TEST_LIB_PATH:=LIBPATH=$(Q)$(TEST_LIB_PATH_VALUE)$(PS)$(LIBPATH)$(Q)
 	else ifneq (,$(findstring zos,$(SPEC)))
-		TEST_LIB_PATH:=LIBPATH=$(Q)$(TEST_LIB_PATH_VALUE)$(PS)$(LIBPATH)$(Q)
+		TEST_LIB_PATH:=LIBPATH=$(Q)$(TEST_LIB_PATH_VALUE)$(PS)$(LIB_PATH)$(PS)$(LIBPATH)$(Q)
 	else ifneq (,$(findstring osx,$(SPEC)))
 		TEST_LIB_PATH:=DYLD_LIBRARY_PATH=$(Q)$(TEST_LIB_PATH_VALUE)$(PS)$(DYLD_LIBRARY_PATH)$(Q)
 	else


### PR DESCRIPTION
In order to find libwrappers.so

Closes #51

Testing
- shrtest job/Grinder_zos/9 - passed
- sanity.functional job/Grinder_zos/10 - no test summary was created