### PR TITLE
Generate parallel list locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,8 @@ test_output_*
 
 # misc auto generated files
 autoGen.mk
-dependencies.mk
 utils.mk
-count.mk
+parallelList.mk
 *.log
 *.tap
 machineConfigure.mk

--- a/makeGen.mk
+++ b/makeGen.mk
@@ -36,7 +36,7 @@ autoconfig:
 	perl scripts$(D)configure.pl
 
 autogen: autoconfig
-	${TEST_JDK_HOME}/bin/java -cp ./bin/TestKitGen.jar org.testKitGen.MainRunner --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) $(OPTS)
+	${TEST_JDK_HOME}/bin/java -cp ./bin/TestKitGen.jar org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachine=$(NUM_MACHINE) --testTime=$(TEST_TIME) $(OPTS)
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)
 AUTOGEN_FILES += $(wildcard $(CURRENT_DIR)$(D)machineConfigure.mk)

--- a/makefile
+++ b/makefile
@@ -41,10 +41,12 @@ TESTTARGET = $(patsubst _%,%,$(_TESTTARGET))
 ifneq (compile, $(_TESTTARGET))
 ifneq (clean, $(_TESTTARGET))
 ifneq (test, $(_TESTTARGET))
+ifneq (genParallelList, $(_TESTTARGET))
 ifneq (_failed, $(_TESTTARGET))
 $(_TESTTARGET):
-	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) TESTTARGET=$(TESTTARGET) TESTLIST=$(TESTLIST)
+	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) MODE=tests TESTTARGET=$(TESTTARGET) TESTLIST=$(TESTLIST)
 	$(MAKE) -f runtest.mk $(_TESTTARGET)
+endif
 endif
 endif
 endif
@@ -84,6 +86,11 @@ _failed:
 
 .NOTPARALLEL: _failed
 
+#######################################
+# generate parallel list
+#######################################
+genParallelList:
+	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) MODE=parallelList NUM_MACHINE=$(NUM_MACHINE) TEST_TIME=$(TEST_TIME) TESTTARGET=$(TEST) TESTLIST=$(TESTLIST)
 
 #######################################
 # clean

--- a/scripts/build_tools.xml
+++ b/scripts/build_tools.xml
@@ -43,6 +43,7 @@
 	<target name="clean" description="clean up">
 		<delete file="../autoGenEnv.mk" />
 		<delete file="../utils.mk" />
+		<delete file="../parallelList.mk" />
 		<delete dir="${build}" />
 	</target>
 

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -234,7 +234,7 @@ sub resultReporter {
 			$customTargetParam = "&CUSTOM_TARGET=" . $customTarget;
 		}
 		my $hudsonUrl = $ENV{'HUDSON_URL'};
-		if ($hudsonUrl eq '') {
+		if (length $hudsonUrl == 0) {
 			$hudsonUrl = "https://ci.adoptopenjdk.net/";
 		}
 		print "To rebuild the failed test in a jenkins job, copy the following link and fill out the <Jenkins URL> and <FAILED test target>:\n";

--- a/src/org/testKitGen/Constants.java
+++ b/src/org/testKitGen/Constants.java
@@ -26,6 +26,7 @@ public final class Constants {
 	public static final String TESTMK = "autoGen.mk";
 	public static final String UTILSMK = "utils.mk";
 	public static final String SETTINGSMK = "settings.mk";
+	public static final String PARALLELMK = "parallelList.mk";
 	public static final String HEADERCOMMENTS = "########################################################\n"
 			+ "# This is an auto generated file. Please do NOT modify!\n"
 			+ "########################################################\n\n";

--- a/src/org/testKitGen/MainRunner.java
+++ b/src/org/testKitGen/MainRunner.java
@@ -20,17 +20,29 @@ public class MainRunner {
 
 	public static void main(String[] args) {
 		Options.parse(args);
-		MainRunner.start();
+		if (Options.getMode() == Options.Mode.GEN_TESTS) {
+			MainRunner.genTests();
+		} else if (Options.getMode() == Options.Mode.GEN_PARALLEL_LIST) {
+			MainRunner.genParallelList();
+		}
 	}
 
-	public static void start() {
+	public static void genTests() {
 		System.out.println("\nStarting to generate test make files.\n");
 		ModesDictionary.parse();
-		MkTreeGen.start();
+		DirectoryWalker.start();
 		Utils.generateFile();
 		System.out.println("\nMake files are generated successfully.\n");
 		if (!TestTarget.getTestSet().isEmpty()) {
 			System.out.println("Warning: cannot find the following tests " + TestTarget.getTestSet().toString().replaceAll("\\s+","") + " in TESTLIST\n");
 		}
+	}
+
+	public static void genParallelList() {
+		System.out.println("\nStarting to generate parallel test lists.\n");
+		ModesDictionary.parse();
+		DirectoryWalker.start();
+		TestDivider.generateLists();
+		System.out.println("\nParallel test lists are generated successfully.\n");
 	}
 }

--- a/src/org/testKitGen/PlaylistInfo.java
+++ b/src/org/testKitGen/PlaylistInfo.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package org.testKitGen;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class PlaylistInfo {
+	private File playlistXML = null;
+	private List<TestInfo> testInfoList;
+	private String include = null;
+
+	public PlaylistInfo(File playlistXML) {
+		this.playlistXML = playlistXML;
+		this.testInfoList = new ArrayList<TestInfo>();
+	}
+
+	public String getInclude() {
+		return include;
+	}
+
+	public List<TestInfo> getTestInfoList() {
+		return testInfoList;
+	}
+
+	public boolean parseInfo() {
+		if (playlistXML == null) return false;
+		try {
+			Document xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(playlistXML);
+			NodeList childNodes = xml.getDocumentElement().getChildNodes();
+
+			for (int i = 0; i < childNodes.getLength(); i++) {
+				Node currentNode = childNodes.item(i);
+
+				if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
+					Element currentElement = ((Element) currentNode);
+					if (currentElement.getNodeName().equals("include")) {
+						include = currentElement.getTextContent();
+					} else if (currentElement.getNodeName().equals("test")) {
+						TestInfo testInfo = new TestInfo(currentElement);
+						if (testInfo.parseInfo()) {
+							testInfoList.add(testInfo);
+						}
+					}
+				}
+			}
+		} catch (SAXException | IOException | ParserConfigurationException e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+		return testInfoList.size() != 0;
+	}
+}

--- a/src/org/testKitGen/TestDivider.java
+++ b/src/org/testKitGen/TestDivider.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package org.testKitGen;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestDivider {
+	private static List<String> regularTests = new ArrayList<String>();
+	private static List<String> effortlessTests = new ArrayList<String>();	// tests almost take no time
+
+
+	
+	private static String parallelmk = Options.getProjectRootDir() + "/TKG/" + Constants.PARALLELMK;
+	private static List<List<String>> parallelLists = new ArrayList<List<String>>();
+	private static int avgTestTime = 2;
+	private TestDivider() {
+	}
+
+	public static void addTests(File playlistXML) {
+		PlaylistInfo pli = new PlaylistInfo(playlistXML);
+		if (pli.parseInfo()) {
+			for (TestInfo testInfo : pli.getTestInfoList()) {
+				for (Variation var : testInfo.getVars()) {
+					String testName = var.getSubTestName();
+					if (TestTarget.isSingleTest() || TestTarget.isList()) {
+						if (var.isValid()) {
+							regularTests.add(testName);
+						} else {
+							effortlessTests.add(testName);
+						}
+					} else if (TestTarget.isCategory()) {
+						if (!var.isValid()) {
+							effortlessTests.add(testName);
+						} else {
+							if (TestTarget.isDisabled() == testInfo.isDisabled()) {
+								regularTests.add(testName);
+							} else {
+								effortlessTests.add(testName);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void divideOnTestTime(int testTime) {
+		int testEachList = testTime / avgTestTime;
+		/* If a single test time is bigger than allowed time on each machine, run 1 test per machine. */
+		if (testEachList == 0) {
+			testEachList = 1;
+		}
+		/* Populate regular tests first and append the effortless along to the regular test lists. */
+		populateParallelLists(regularTests, testEachList, 0);
+
+		/* If no regular test, no need to divide the effortless tests. */
+		int numOfMachine = parallelLists.size() != 0 ? parallelLists.size() : 1;
+		testEachList = effortlessTests.size() / numOfMachine;
+		int remainder = effortlessTests.size() % numOfMachine;
+		populateParallelLists(effortlessTests, testEachList, remainder);
+	}
+
+	private static void divideOnMachineNum(int numOfMachine) {
+		int testEachList = regularTests.size() / numOfMachine;
+		int remainder = regularTests.size() % numOfMachine;
+		populateParallelLists(regularTests, testEachList, remainder);
+
+		testEachList = effortlessTests.size() / numOfMachine;
+		remainder = effortlessTests.size() % numOfMachine;
+		populateParallelLists(effortlessTests, testEachList, remainder);
+	}
+
+
+	public static void generateLists() {
+		if (Options.getNumOfMachine() == null) {
+			if (Options.getTestTime() == null) {
+				divideOnMachineNum(1);
+			} else {
+				divideOnTestTime(Options.getTestTime());
+			}
+		} else {
+			divideOnMachineNum(Options.getNumOfMachine());
+		}
+
+		try {
+			FileWriter f = new FileWriter(parallelmk);
+			f.write(Constants.HEADERCOMMENTS);
+			f.write("NUM_LIST=" + parallelLists.size() + "\n\n");
+			for (int i = 0; i < parallelLists.size(); i++) {
+				f.write("testList_" + i + ":\n");
+				f.write("\t$(MAKE) _testList TESTLIST=");
+				for (int j = 0; j < parallelLists.get(i).size(); j++) {
+					f.write(parallelLists.get(i).get(j));
+					if (j != parallelLists.get(i).size() - 1) {
+						f.write(",");
+					}
+				}
+				f.write("\n\n");
+			}
+			f.close();
+			System.out.println();
+			System.out.println("Generated " + parallelmk + "\n");
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+
+		int totalNum = regularTests.size() + effortlessTests.size();
+		System.out.println("Test target (" + totalNum + " tests) is splitted into " + parallelLists.size() + " lists as follows:\n");
+
+		for (int i = 0; i < parallelLists.size(); i++) {
+			System.out.println("-------------------------------------testList_" + i + "-------------------------------------");
+			System.out.println("number of tests in the list: " + parallelLists.get(i).size());
+			System.out.print("TESTLIST=");
+			for (int j = 0; j < parallelLists.get(i).size(); j++) {
+				System.out.print(parallelLists.get(i).get(j));
+				if (j != parallelLists.get(i).size() - 1) {
+					System.out.print(",");
+				}
+			}
+			System.out.println("\n------------------------------------------------------------------------------------\n");
+		}
+	}
+
+	private static void populateParallelLists(List<String> tests, int testEachList, int remainder) {
+		/* it's better to have adjacent tests stay archived together */
+		int listIndex = 0;
+		int start = 0;
+		while (start < tests.size()) {
+			int end = start + testEachList;
+			if (remainder > 0) {
+				end += 1;
+				remainder--;
+			}
+			if (listIndex >= parallelLists.size()) {
+				parallelLists.add(new ArrayList<String>());
+			}
+			/* when divideOnTestTime(), the end might be bigger than test.size() */
+			if (end > tests.size()) {
+				end = tests.size();
+			}
+			parallelLists.get(listIndex).addAll(tests.subList(start, end));
+			listIndex++;
+			start = end;
+		}
+	}
+}


### PR DESCRIPTION
- running mode parallelList, it will split tests and generate parallelList.mk
- we can run testList_<index> target in parallelList.mk to invoke splitted list
- add new mode: parallelList and additional options
- rename MkTreeGen to DirectoryWalker and modify it to support both modes
- restructure MkGen and separate PlaylistInfo from it
- add TestDivider to handle parallelList generation
- modify makefiles and build files

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>