### PR TITLE
Remove parallel.mk from clean step

### DIFF
--- a/scripts/build_tools.xml
+++ b/scripts/build_tools.xml
@@ -43,7 +43,6 @@
 	<target name="clean" description="clean up">
 		<delete file="../autoGenEnv.mk" />
 		<delete file="../utils.mk" />
-		<delete file="../parallelList.mk" />
 		<delete dir="${build}" />
 	</target>
 


### PR DESCRIPTION
- since child build might do make clean before executing tests
- rely on FileWrite() to overwrite parallel.mk when genParallel

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>