### PR TITLE
Link TRSS for dynamic paralellization

### DIFF
--- a/compile.mk
+++ b/compile.mk
@@ -23,14 +23,6 @@ endif
 include settings.mk
 
 #######################################
-# download all dependent jars
-#######################################
-getdependency:
-	perl scripts$(D)getDependencies.pl -path '$(TEST_ROOT)$(D)TKG$(D)lib' -task default -os $(OS)
-
-.PHONY: getdependency
-
-#######################################
 # compile all tests under $(TEST_ROOT)
 #######################################
 COMPILATION_LOG=$(TESTOUTPUT)$(D)compile$(D)compilation.log
@@ -38,7 +30,7 @@ MOVE_TDUMP_PERL=perl scripts$(D)moveDmp.pl --compileLogPath=$(Q)$(COMPILATION_LO
 MOVE_TDUMP=if [ -z $$(tail -n 1 $(COMPILATION_LOG) | grep 0) ]; then $(MOVE_TDUMP_PERL); $(RM) $(Q)$(COMPILATION_LOG)$(Q); false; else $(RM) $(Q)$(COMPILATION_LOG)$(Q); fi
 COMPILE_CMD=ant -f scripts$(D)build_test.xml -DTEST_ROOT=$(TEST_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJDK_VERSION=$(JDK_VERSION) -DJDK_IMPL=$(JDK_IMPL) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DRESOURCES_DIR=${RESOURCES_DIR} -DSPEC=${SPEC} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJVM_VERSION=$(JVM_VERSION) -DLIB_DIR=$(LIB_DIR)
 
-compile: getdependency
+compile:
 	$(MKTREE) $(TESTOUTPUT)$(D)compile; \
 	($(COMPILE_CMD) 2>&1; echo $$? ) | tee $(Q)$(COMPILATION_LOG)$(Q); \
 	$(MOVE_TDUMP)

--- a/makeGen.mk
+++ b/makeGen.mk
@@ -24,9 +24,15 @@ CURRENT_DIR := $(shell pwd)
 OPTS=
 
 D=/
+P=:
+Q="
+
+TKG_JAR = .$(D)bin$(D)TestKitGen.jar
+JSON_SIMPLE = .$(D)lib$(D)json-simple.jar
 
 ifneq (,$(findstring Win,$(OS)))
 CURRENT_DIR := $(subst \,/,$(CURRENT_DIR))
+P=;
 endif
 include $(CURRENT_DIR)$(D)featureSettings.mk
 -include $(CURRENT_DIR)$(D)autoGenEnv.mk
@@ -36,7 +42,7 @@ autoconfig:
 	perl scripts$(D)configure.pl
 
 autogen: autoconfig
-	${TEST_JDK_HOME}/bin/java -cp ./bin/TestKitGen.jar org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachine=$(NUM_MACHINES) --testTime=$(TEST_TIME) $(OPTS)
+	${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachines=$(NUM_MACHINES) --testTime=$(TEST_TIME) --TRSSURL=$(TRSS_URL) $(OPTS)
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)
 AUTOGEN_FILES += $(wildcard $(CURRENT_DIR)$(D)machineConfigure.mk)

--- a/makefile
+++ b/makefile
@@ -34,6 +34,14 @@ ifndef TEST_ROOT
 endif
 
 #######################################
+# download all dependent jars
+#######################################
+getdependency:
+	perl scripts$(D)getDependencies.pl -path '$(TEST_ROOT)$(D)TKG$(D)lib' -task default
+
+.PHONY: getdependency
+
+#######################################
 # run test
 #######################################
 _TESTTARGET = $(firstword $(MAKECMDGOALS))
@@ -62,7 +70,7 @@ compile: compileTools
 # compile tools
 # If AUTO_DETECT is turned on, compile and execute envDetector in build_envInfo.xml.
 #######################################
-compileTools:
+compileTools: getdependency
 	ant -f .$(D)scripts$(D)build_tools.xml -DTEST_JDK_HOME=$(TEST_JDK_HOME)
 ifneq ($(AUTO_DETECT), false)
 	@echo "AUTO_DETECT is set to true"
@@ -95,7 +103,7 @@ _failed:
 # generate parallel list
 #######################################
 genParallelList: compileTools
-	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) MODE=parallelList NUM_MACHINES=$(NUM_MACHINES) TEST_TIME=$(TEST_TIME) TESTTARGET=$(TEST) TESTLIST=$(TESTLIST)
+	$(MAKE) -f makeGen.mk AUTO_DETECT=$(AUTO_DETECT) MODE=parallelList NUM_MACHINES=$(NUM_MACHINES) TEST_TIME=$(TEST_TIME) TESTTARGET=$(TEST) TESTLIST=$(TESTLIST) TRSS_URL=$(TRSS_URL)
 
 #######################################
 # clean

--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+linux_arm=aarch32_linux
+linux_aarch64_cmprssptrs=aarch64_linux
+linux_aarch64=aarch64_linux_xl
+aix_ppc=ppc32_aix
+linux_ppc=ppc32_linux
+aix_ppc-64_cmprssptrs=ppc64_aix
+aix_ppc-64=ppc64_aix_xl
+linux_ppc-64_cmprssptrs=ppc64_linux
+linux_ppc-64=ppc64_linux_xl
+linux_ppc-64_cmprssptrs_le=ppc64le_linux
+linux_ppc-64_le=ppc64le_linux_xl
+linux_390=s390_linux
+zos_390=s390_zos
+linux_390-64_cmprssptrs=s390x_linux
+linux_390-64=s390x_linux_xl
+zos_390-64_cmprssptrs=s390x_zos
+zos_390-64=s390x_zos_xl
+sunos_sparcv9-64_cmprssptrs=sparcv9_solaris
+linux_x86=x86-32_linux
+win_x86=x86-32_windows
+linux_x86-64_cmprssptrs=x86-64_linux
+linux_x86-64=x86-64_linux_xl
+osx_x86-64_cmprssptrs=x86-64_mac
+osx_x86-64=x86-64_mac_xl
+win_x86-64_cmprssptrs=x86-64_windows
+win_x86-64=x86-64_windows_xl

--- a/scripts/build_tools.xml
+++ b/scripts/build_tools.xml
@@ -21,6 +21,7 @@
 
 	<property name="src" location="../src" />
 	<property name="build" location="../bin" />
+	<property name="json.jar" location="../lib/json-simple.jar" />
 
 	<target name="init">
 		<mkdir dir="${build}" />
@@ -31,7 +32,11 @@
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===debug:                        on</echo>
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${TEST_JDK_HOME}/bin/javac" includeAntRuntime="false" encoding="ISO-8859-1"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${TEST_JDK_HOME}/bin/javac" includeAntRuntime="false" encoding="ISO-8859-1">
+			<classpath>
+				<pathelement location="${json.jar}" />
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -234,7 +234,7 @@ sub resultReporter {
 			$customTargetParam = "&CUSTOM_TARGET=" . $customTarget;
 		}
 		my $hudsonUrl = $ENV{'HUDSON_URL'};
-		if (length $hudsonUrl == 0) {
+		if ((!defined $hudsonUrl) || ($hudsonUrl eq '')) {
 			$hudsonUrl = "https://ci.adoptopenjdk.net/";
 		}
 		print "To rebuild the failed test in a jenkins job, copy the following link and fill out the <Jenkins URL> and <FAILED test target>:\n";

--- a/src/org/testKitGen/Constants.java
+++ b/src/org/testKitGen/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
 	public static final String PLAYLIST = "playlist.xml";
 	public static final String MODESXML = "resources/modes.xml";
 	public static final String OTTAWACSV = "resources/ottawa.csv";
+	public static final String BUILDPLAT_JSON = "resources/buildPlatformMap.properties";
 	public static final String TESTMK = "autoGen.mk";
 	public static final String UTILSMK = "utils.mk";
 	public static final String SETTINGSMK = "settings.mk";
@@ -39,7 +40,7 @@ public final class Constants {
 			.asList("linux_x86-32_hrt", "linux_x86-64_cmprssptrs_gcnext", "linux_ppc_purec", "linux_ppc-64_purec",
 					"linux_ppc-64_cmprssptrs_purec", "linux_x86-64_cmprssptrs_cloud")
 			.stream().collect(Collectors.toSet());
-
+	public static final String TRSS_URL = "https://trss.adoptopenjdk.net";
 	private Constants() {
 	}
 }

--- a/src/org/testKitGen/MainRunner.java
+++ b/src/org/testKitGen/MainRunner.java
@@ -43,6 +43,5 @@ public class MainRunner {
 		ModesDictionary.parse();
 		DirectoryWalker.start();
 		TestDivider.generateLists();
-		System.out.println("\nParallel test lists are generated successfully.\n");
 	}
 }

--- a/src/org/testKitGen/ModesDictionary.java
+++ b/src/org/testKitGen/ModesDictionary.java
@@ -44,7 +44,6 @@ public class ModesDictionary {
 	}
 
 	public static void parse() {
-		System.out.println("Getting modes data from " + Constants.MODESXML + " and " + Constants.OTTAWACSV + "...");
 		try {
 			Element modes = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(modesXml)
 					.getDocumentElement();
@@ -54,6 +53,7 @@ public class ModesDictionary {
 			e.printStackTrace();
 			System.exit(1);
 		}
+		System.out.println("Modes data parsed from " + Constants.MODESXML + " and " + Constants.OTTAWACSV + ".\n");
 	}
 
 	public static void parseMode(Element modes) {

--- a/src/org/testKitGen/Options.java
+++ b/src/org/testKitGen/Options.java
@@ -26,8 +26,9 @@ public class Options {
 	private static String buildList = "";
 	private static String iterations = "";
 	private static String testFlag = "";
-	private static Integer numOfMachine = null;
+	private static Integer numOfMachines = null;
 	private static Integer testTime = null;
+	private static String TRSSURL = "";
 
 	private static final String usage = "Usage:\n"
 			+ "    java TestKitGen --mode=[tests|parallelList] --spec=[linux_x86-64] --jdkVersion=[8|9|...] --impl=[openj9|ibm|hotspot|sap] [options]\n\n"
@@ -48,10 +49,12 @@ public class Options {
 			+ "                              Defaults to \"\"\n"
 			+ "    --testTarget=<string>     Test target to execute\n"
 			+ "                              Defaults to all\n"
-			+ "    --numOfMachine=<number>   Specify number of machines for mode parallelList \n"
+			+ "    --numOfMachines=<number>   Specify number of machines for mode parallelList \n"
 			+ "                              Defaults to 1\n"
-			+ "    --testTime=<number>       Specify expected length of test running time (minutes) on each machines for mode parallelList, this option will be suppressed if numOfMachine is given\n"
-			+ "                              If testTime and numOfMachine are not provided, default numOfMachine will be used\n";
+			+ "    --testTime=<number>       Specify expected length of test running time (minutes) on each machines for mode parallelList, this option will be suppressed if numOfMachines is given\n"
+			+ "                              If testTime and numOfMachines are not provided, default numOfMachines will be used\n"
+			+ "    --TRSSURL=<serverURL>  Specify the TRSS server URL for mode parallelList\n"
+			+ "                              Defaults to " + Constants.TRSS_URL + "\n";
 			
 
 	private Options() {
@@ -89,12 +92,16 @@ public class Options {
 		return testFlag;
 	}
 
-	public static Integer getNumOfMachine() {
-		return numOfMachine;
+	public static Integer getNumOfMachines() {
+		return numOfMachines;
 	}
 
 	public static Integer getTestTime() {
 		return testTime;
+	}
+
+	public static String getTRSSURL() {
+		return TRSSURL;
 	}
 
 	public static void parse(String[] args) {
@@ -136,13 +143,16 @@ public class Options {
 			} else if (arglc.startsWith("--testtarget=")) {
 				// test Target is case sensitive
 				testTarget = arg.substring(arg.indexOf("=") + 1);
-			} else if (arglc.startsWith("--numofmachine")) {
-				String numOfMachineStr = arg.substring(arg.indexOf("=") + 1);
-				if (!numOfMachineStr.isEmpty()) {
-					numOfMachine = Integer.valueOf(numOfMachineStr);
-					if (numOfMachine <= 0) {
+			} else if (arglc.startsWith("--trssurl=")) {
+				// TRSSURL is case sensitive
+				TRSSURL = arg.substring(arg.indexOf("=") + 1);
+			} else if (arglc.startsWith("--numofmachines")) {
+				String numOfMachinesStr = arg.substring(arg.indexOf("=") + 1);
+				if (!numOfMachinesStr.isEmpty()) {
+					numOfMachines = Integer.valueOf(numOfMachinesStr);
+					if (numOfMachines <= 0) {
 						System.err.println("Invalid option: " + arg);
-						System.err.println("Num of machine needs to be bigger than 0");
+						System.err.println("Num of machines need to be bigger than 0");
 						System.exit(1);
 					}
 				}

--- a/src/org/testKitGen/TestDivider.java
+++ b/src/org/testKitGen/TestDivider.java
@@ -13,21 +13,34 @@
 *******************************************************************************/
 
 package org.testKitGen;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.FileReader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 public class TestDivider {
-	private static List<String> regularTests = new ArrayList<String>();
-	private static List<String> effortlessTests = new ArrayList<String>();	// tests almost take no time
-
-
+	private static List<String> regularTests = new ArrayList<>();
+	private static List<String> effortlessTests = new ArrayList<>();	// tests almost take no time
+	private static boolean dataFromTRSS = false;
+	private static Queue<Map.Entry<String, Integer>> testTimeQueue = new PriorityQueue<>(
+		(a, b) -> a.getValue() == b.getValue() ? b.getKey().compareTo(a.getKey()) : b.getValue().compareTo(a.getValue())
+	);
+	private static Map<Integer, Integer> testListTime = new HashMap<>();
 	
 	private static String parallelmk = Options.getProjectRootDir() + "/TKG/" + Constants.PARALLELMK;
-	private static List<List<String>> parallelLists = new ArrayList<List<String>>();
-	private static int avgTestTime = 2;
+	private static List<List<String>> parallelLists = new ArrayList<>();
+	private static int defaultAvgTestTime = 40000; // in milliseconds
 	private TestDivider() {
 	}
 
@@ -60,41 +73,234 @@ public class TestDivider {
 	}
 
 	private static void divideOnTestTime(int testTime) {
-		int testEachList = testTime / avgTestTime;
+		int testsInEachList = testTime / defaultAvgTestTime;
 		/* If a single test time is bigger than allowed time on each machine, run 1 test per machine. */
-		if (testEachList == 0) {
-			testEachList = 1;
+		if (testsInEachList == 0) {
+			testsInEachList = 1;
 		}
 		/* Populate regular tests first and append the effortless along to the regular test lists. */
-		populateParallelLists(regularTests, testEachList, 0);
+		populateParallelLists(regularTests, testsInEachList, 0);
 
 		/* If no regular test, no need to divide the effortless tests. */
-		int numOfMachine = parallelLists.size() != 0 ? parallelLists.size() : 1;
-		testEachList = effortlessTests.size() / numOfMachine;
-		int remainder = effortlessTests.size() % numOfMachine;
-		populateParallelLists(effortlessTests, testEachList, remainder);
+		int numOfMachines = parallelLists.size() != 0 ? parallelLists.size() : 1;
+		testsInEachList = effortlessTests.size() / numOfMachines;
+		int remainder = effortlessTests.size() % numOfMachines;
+		populateParallelLists(effortlessTests, testsInEachList, remainder);
 	}
 
-	private static void divideOnMachineNum(int numOfMachine) {
-		int testEachList = regularTests.size() / numOfMachine;
-		int remainder = regularTests.size() % numOfMachine;
-		populateParallelLists(regularTests, testEachList, remainder);
+	private static void divideOnMachineNum(int numOfMachines) {
+		if (dataFromTRSS) {
+			Queue<Map.Entry<Integer, Integer>> machineQueue = new PriorityQueue<>(
+				(a, b) -> a.getValue() == b.getValue() ? a.getKey().compareTo(b.getKey()) : a.getValue().compareTo(b.getValue())
+			);
 
-		testEachList = effortlessTests.size() / numOfMachine;
-		remainder = effortlessTests.size() % numOfMachine;
-		populateParallelLists(effortlessTests, testEachList, remainder);
+			for (int i = 0; i < numOfMachines; i++) {
+				testListTime.put(i, 0);
+			}
+			for (Map.Entry<Integer, Integer> entry : testListTime.entrySet()) {
+				machineQueue.offer(entry);
+			}
+			for (int i = 0; i < numOfMachines; i++) {
+				parallelLists.add(new ArrayList<String>());
+			}
+			while (!testTimeQueue.isEmpty()) {
+				Map.Entry<String, Integer> testEntry = testTimeQueue.poll();
+				Map.Entry<Integer, Integer> machineEntry = machineQueue.poll();
+
+				parallelLists.get(machineEntry.getKey()).add(testEntry.getKey());
+				int newTime = machineEntry.getValue() + testEntry.getValue();
+				machineEntry.setValue(newTime);
+
+				machineQueue.offer(machineEntry);
+			}
+		} else {
+			int testsInEachList = regularTests.size() / numOfMachines;
+			int remainder = regularTests.size() % numOfMachines;
+			populateParallelLists(regularTests, testsInEachList, remainder);
+
+			testsInEachList = effortlessTests.size() / numOfMachines;
+			remainder = effortlessTests.size() % numOfMachines;
+			populateParallelLists(effortlessTests, testsInEachList, remainder);
+		}
 	}
 
+	private static String constructURL() {
+		int limit = 10; // limit the number of builds used to calculate the average duration 
+		String URL = (Options.getTRSSURL().isEmpty() ? Constants.TRSS_URL : Options.getTRSSURL()) + "/api/getTestAvgDuration?limit=" + limit + "&jdkVersion=" + Options.getJdkVersion();
+
+		String impl = Options.getImpl();
+		if (impl.equals("openj9")) {
+			impl = "j9";
+		} else if (impl.equals("hotspot")) {
+			impl = "hs";
+		}
+		URL += "&impl=" + impl;
+
+		String plat = Options.getSpec();
+		try (FileReader platReader = new FileReader(Constants.BUILDPLAT_JSON)) {
+			Properties platProp = new Properties();
+			platProp.load(platReader);
+			plat = platProp.getProperty(Options.getSpec());
+		} catch (IOException e) {
+			// nothing to do
+		}
+		URL += "&platform=" + plat;
+
+		if (TestTarget.isSingleTest()) {
+			URL += "&testName=" + TestTarget.getTestTarget();
+		} else if (TestTarget.isCategory()) {
+			String group = "";
+			for (String g : Constants.ALLGROUPS) {
+				if (TestTarget.getCategorySet().contains(g)) {
+					if (group.equals("")) {
+						group = g;
+					} else {
+						group = "";
+						break;
+					}
+				}
+			}
+			if (!group.equals("")) {
+				URL += "&group=" + group; 
+			}
+			String level = "";
+			for (String l : Constants.ALLLEVELS) {
+				if (TestTarget.getCategorySet().contains(l)) {
+					if (level.equals("")) {
+						level = l;
+					} else {
+						level = "";
+						break;
+					}
+				}
+			}
+			if (!level.equals("")) {
+				URL += "&level=" + level; 
+			}
+		} 
+		return URL;
+	}
+
+
+	private static Map<String, Integer> getMapFromTRSS() {
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		String URL = constructURL();
+		String command = "curl --silent --max-time 120 " + URL;
+		System.out.println("Attempting to get test duration data from TRSS:");
+		System.out.println(command);
+		try {
+			Process process = Runtime.getRuntime().exec(command);
+			InputStream responseStream = process.getInputStream();
+			BufferedReader responseReader = new BufferedReader(new InputStreamReader(responseStream));
+			JSONParser parser = new JSONParser();
+			JSONObject jsonObject = (JSONObject) parser.parse(responseReader);
+			JSONArray buckets = (JSONArray) jsonObject.get("buckets");
+			if (buckets != null && buckets.size() != 0) {
+				JSONArray bucket = (JSONArray) buckets.get(0);
+				if (bucket != null) {
+					for (int i = 0; i < bucket.size(); i++) {
+						JSONObject testData = (JSONObject) bucket.get(i);
+						String testName = (String) testData.get("_id");
+						Number testDurationNum = (Number) testData.get("avgDuration");
+						if (testName != null && testDurationNum != null) {
+							Double testDuration = ((Number) testData.get("avgDuration")).doubleValue();
+							map.put(testName, testDuration.intValue());
+						}
+					}
+				}
+			}
+		} catch (IOException | ParseException e) {
+			System.out.println("Warning: cannot get data from TRSS.");
+		}
+
+		return map;
+	}
+
+	private static void buildTestTimeQueue() {
+		Map<String, Integer> TRSSMap = getMapFromTRSS();
+		Map<String, Integer> actualTestMap = new HashMap<>();
+		List<String> testsNotFound = new ArrayList<>();
+		if (TRSSMap.size() != 0) {
+			for (String test : regularTests) {
+				if (TRSSMap.containsKey(test)) {
+					actualTestMap.put(test, TRSSMap.get(test));
+					dataFromTRSS = true;
+				} else {
+					actualTestMap.put(test, defaultAvgTestTime);
+					testsNotFound.add(test);
+				}
+			}
+			for (String test : effortlessTests) {
+				if (TRSSMap.containsKey(test)) {
+					actualTestMap.put(test, TRSSMap.get(test));
+					dataFromTRSS = true;
+				} else {
+					actualTestMap.put(test, 0);
+					testsNotFound.add(test);
+				}
+			}
+			for (Map.Entry<String, Integer> entry : actualTestMap.entrySet()) {
+				testTimeQueue.offer(entry);
+			}
+		}
+		System.out.println("\nTEST DURATION");
+		System.out.println("====================================================================================");
+		int totalNum = regularTests.size() + effortlessTests.size();
+		System.out.println("Total number of tests searched: " + totalNum);
+		if (dataFromTRSS) {
+			int foundNum = testTimeQueue.size() - testsNotFound.size();
+			System.out.println("Number of test durations found: " + foundNum);
+			System.out.println("Top slowest tests: ");
+			List<Map.Entry<String, Integer>> lastTests = new ArrayList<>();
+			for (int i = 0; i < Math.min(foundNum, 3); i++) {
+				lastTests.add(testTimeQueue.poll());
+			}
+			for (int i = 0; i < lastTests.size(); i++) {
+				System.out.println("\t" + formatTime(lastTests.get(i).getValue()) + " " + lastTests.get(i).getKey());
+				testTimeQueue.offer(lastTests.get(i));
+			}
+			if (!testsNotFound.isEmpty()) {
+				System.out.println("Following test duration data cannot be found: ");
+				System.out.println("(Default duration assigned, running tests: " + defaultAvgTestTime / 1000 + "s; skipped/disabled tests: 0s.)");
+				System.out.println(testsNotFound.toString());
+			}
+		} else {
+			System.out.println("No test duration data found.");
+			System.out.println("(Default duration assigned, running tests: " + defaultAvgTestTime / 1000 + "s; skipped/disabled tests: 0s.)");
+
+		}
+		System.out.println("====================================================================================");
+	}
+
+	private static String formatTime(int milliSec) {
+		int sec = milliSec / 1000;
+		String duration = String.format("%02dm%02ds", sec / 60, sec % 60);
+		return duration;
+	}
 
 	public static void generateLists() {
-		if (Options.getNumOfMachine() == null) {
+		if (regularTests.size() == 0 && effortlessTests.size() == 0) {
+			System.out.println("No tests found for target: " + TestTarget.getTestTarget());
+			System.out.println("No parallel test lists generated.");
+			return;
+		}
+
+		if (TestTarget.isDisabled()) {
+			// TRSS does not contain test duration for running disabled test at this moment
+			System.out.println("Warning: Test duration data cannot be found for executing disabled target.");
+			System.out.println("(Default duration assigned, running tests: " + defaultAvgTestTime / 1000 + "s; skipped tests: 0s.)");
+		} else {
+			buildTestTimeQueue();
+		}
+	
+		if (Options.getNumOfMachines() == null) {
 			if (Options.getTestTime() == null) {
 				divideOnMachineNum(1);
 			} else {
 				divideOnTestTime(Options.getTestTime());
 			}
 		} else {
-			divideOnMachineNum(Options.getNumOfMachine());
+			divideOnMachineNum(Math.max(1, Math.min(Options.getNumOfMachines(), regularTests.size())));
 		}
 
 		try {
@@ -113,19 +319,30 @@ public class TestDivider {
 				f.write("\n\n");
 			}
 			f.close();
-			System.out.println();
-			System.out.println("Generated " + parallelmk + "\n");
 		} catch (IOException e) {
 			e.printStackTrace();
 			System.exit(1);
 		}
 
-		int totalNum = regularTests.size() + effortlessTests.size();
-		System.out.println("Test target (" + totalNum + " tests) is splitted into " + parallelLists.size() + " lists as follows:\n");
+		System.out.println("\nTest target is split into " + parallelLists.size() + " lists.");
+
+		if (dataFromTRSS) {
+			int maxListTime = 0;
+			int totalTime = 0;
+			for (int listTime : testListTime.values()) {
+				maxListTime = maxListTime > listTime ? maxListTime : listTime;
+				totalTime += listTime;
+			}
+			System.out.println("Reducing estimated test running time from " + formatTime(totalTime) + " to " + formatTime(maxListTime) + ".\n");
+		}
 
 		for (int i = 0; i < parallelLists.size(); i++) {
+			
 			System.out.println("-------------------------------------testList_" + i + "-------------------------------------");
-			System.out.println("number of tests in the list: " + parallelLists.get(i).size());
+			System.out.println("Number of tests: " + parallelLists.get(i).size());
+			if (dataFromTRSS) {
+				System.out.println("Estimated running time: " + formatTime(testListTime.get(i)));
+			}
 			System.out.print("TESTLIST=");
 			for (int j = 0; j < parallelLists.get(i).size(); j++) {
 				System.out.print(parallelLists.get(i).get(j));
@@ -133,16 +350,21 @@ public class TestDivider {
 					System.out.print(",");
 				}
 			}
-			System.out.println("\n------------------------------------------------------------------------------------\n");
+			System.out.print("\n------------------------------------------------------------------------------------");
+			for (int j = 1; j < String.valueOf(i).length(); j++) {
+				System.out.print("-");
+			}
+			System.out.println("\n");
 		}
+		System.out.println("Parallel test lists file (" + parallelmk + ") is generated successfully.");
 	}
 
-	private static void populateParallelLists(List<String> tests, int testEachList, int remainder) {
+	private static void populateParallelLists(List<String> tests, int testInList, int remainder) {
 		/* it's better to have adjacent tests stay archived together */
 		int listIndex = 0;
 		int start = 0;
 		while (start < tests.size()) {
-			int end = start + testEachList;
+			int end = start + testInList;
 			if (remainder > 0) {
 				end += 1;
 				remainder--;


### PR DESCRIPTION
- add option TRSS_URL
- update numOfMachine to numOfMachines
- use buildPlatformMap.properties to map SPEC to build platform
- use curl command to get test duration from TRSS
- handle different failure cases when retrieving duration data
- print test duration status
- update default test duration
- use two priority queues to split the tests based on duration
- remove dependencies of EnvDectector for getDependencies
- use json-simple for parsing json result and add it in getDependencies
- update getDependencies to have more precise error info
- fix minor issue with resultsSum

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>