### PR TITLE
Update Mode107-OSRG to match Mode107 value

### DIFF
--- a/resources/ottawa.csv
+++ b/resources/ottawa.csv
@@ -168,7 +168,7 @@ variation:Mode112-OSR,yes,yes,no,yes,yes,no,yes,yes,no,yes,no,yes,yes,no,yes,yes
 variation:Mode607-OSR,no,no,yes,no,no,yes,no,no,yes,no,no,no,no,yes,no,no,yes,no,no,yes,no,no,yes,yes,yes,no,yes
 variation:Mode610-OSR,no,no,yes,no,no,yes,no,no,yes,no,yes,no,no,yes,no,no,yes,no,no,yes,no,no,yes,yes,yes,no,yes
 variation:Mode612-OSR,no,no,yes,no,no,yes,no,no,yes,no,yes,no,no,yes,no,no,yes,no,no,yes,no,no,yes,yes,yes,no,yes
-variation:Mode107-OSRG,yes,yes,no,yes,yes,no,yes,yes,no,no,yes,yes,yes,no,yes,yes,no,yes,yes,no,no,yes,no,no,no,yes,no
+variation:Mode107-OSRG,yes,yes,no,yes,yes,no,yes,yes,no,yes,no,yes,yes,no,yes,yes,no,yes,yes,no,no,yes,no,no,no,yes,no
 variation:Mode110-OSRG,yes,yes,no,yes,yes,no,yes,yes,no,yes,no,yes,yes,no,yes,yes,no,yes,yes,no,yes,yes,no,no,no,yes,no
 variation:Mode607-OSRG,no,no,yes,no,no,yes,no,no,yes,no,no,no,no,yes,no,no,yes,no,no,yes,no,no,yes,yes,yes,no,yes
 variation:Mode610-OSRG,no,no,yes,no,no,yes,no,no,yes,no,yes,no,no,yes,no,no,yes,no,no,yes,no,no,yes,yes,yes,no,yes


### PR DESCRIPTION
Update Mode107-OSRG to match Mode107 value on linux_ppc-64_cmprssptrs_le
and linux_ppc-64_le

Fixes: https://github.com/eclipse/openj9/issues/9579

Signed-off-by: lanxia <lan_xia@ca.ibm.com>