### PR TITLE
Parse core from TKG and envDetector compilation

### DIFF
--- a/moveDmp.mk
+++ b/moveDmp.mk
@@ -12,26 +12,14 @@
 # limitations under the License.
 ##############################################################################
 
-.DEFAULT_GOAL := compile
-
 D = /
 
 ifndef TEST_ROOT
 	TEST_ROOT := $(shell pwd)$(D)..
 endif
 
-include settings.mk
-include moveDmp.mk
+COMPILATION_OUTPUT=$(TEST_ROOT)$(D)TKG$(D)test_output_compilation
+COMPILATION_LOG=$(COMPILATION_OUTPUT)$(D)compilation.log
+MOVE_TDUMP_PERL=perl scripts$(D)moveDmp.pl --compileLogPath=$(Q)$(COMPILATION_LOG)$(Q) --testRoot=$(Q)$(TEST_ROOT)$(Q)
+MOVE_TDUMP=if [ -z $$(tail -n 1 $(COMPILATION_LOG) | grep 0) ]; then $(MOVE_TDUMP_PERL); false; else $(RM) -r $(Q)$(COMPILATION_OUTPUT)$(Q); fi
 
-#######################################
-# compile all tests under $(TEST_ROOT)
-#######################################
-COMPILE_CMD=ant -f scripts$(D)build_test.xml -DTEST_ROOT=$(TEST_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJDK_VERSION=$(JDK_VERSION) -DJDK_IMPL=$(JDK_IMPL) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DRESOURCES_DIR=${RESOURCES_DIR} -DSPEC=${SPEC} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJVM_VERSION=$(JVM_VERSION) -DLIB_DIR=$(LIB_DIR)
-
-compile:
-	$(RM) -r $(COMPILATION_OUTPUT); \
-	$(MKTREE) $(COMPILATION_OUTPUT); \
-	($(COMPILE_CMD) 2>&1; echo $$? ) | tee $(Q)$(COMPILATION_LOG)$(Q); \
-	$(MOVE_TDUMP)
-
-.PHONY: compile

--- a/scripts/moveDmp.pl
+++ b/scripts/moveDmp.pl
@@ -24,23 +24,20 @@ our $FAILURE = 0;
 
 my $path;
 my $testRoot;
-my $spec;
 for (my $i = 0; $i < scalar(@ARGV); $i++) {
 	my $arg = $ARGV[$i];
 	if ($arg =~ /^\-\-compileLogPath=/) {
 		($path) = $arg =~ /^\-\-compileLogPath=(.*)/;
 	} elsif ($arg =~ /^\-\-testRoot=/) {
 		($testRoot) = $arg =~ /^\-\-testRoot=(.*)/;
-	} elsif ($arg =~ /^\-\-spec=/) {
-		($spec) = $arg =~ /^\-\-spec=(.*)/;
 	}
 }
 
-if ($path && $testRoot && $spec) {
+if ($path && $testRoot) {
 	my $location = dirname($path);
 	open my $Log, '<', "$path";
 	my $compileLog = do { local $/; <$Log> };
-	moveTDUMPS($compileLog, $location, $spec);
+	moveTDUMPS($compileLog, $location);
 }
 
 sub logMsg {
@@ -122,11 +119,11 @@ sub checkLog {
 }
 
 sub moveTDUMPS {
-	my ($file, $moveLocation, $spec) = @_;
+	my ($file, $moveLocation) = @_;
 	my @dumplist = ();
 	# Use a hash to ensure that each dump is only dealt with once
 	my %parsedNames = ();
-	if ($spec !~ /zos/) {
+	if ($^O ne 'os390') {
 		my $moveCMD = "find ".${testRoot}." -name 'core.*.dmp' -exec mv -t ".${moveLocation}." '{}' +";
 		qx($moveCMD);
 		return;


### PR DESCRIPTION
- remove SPEC dependency from moveDmp.pl
- separate envDectect from compileTools target
- move moveDmp commands into moveDmp.mk
- add moveDmp command in compileTools target

Fixes #66

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>