### PR TITLE
moveDmp: stop using -n on tail as it is not required and breaks on Solaris

### DIFF
--- a/moveDmp.mk
+++ b/moveDmp.mk
@@ -21,4 +21,4 @@ endif
 COMPILATION_OUTPUT=$(TEST_ROOT)$(D)TKG$(D)test_output_compilation
 COMPILATION_LOG=$(COMPILATION_OUTPUT)$(D)compilation.log
 MOVE_TDUMP_PERL=perl scripts$(D)moveDmp.pl --compileLogPath=$(Q)$(COMPILATION_LOG)$(Q) --testRoot=$(Q)$(TEST_ROOT)$(Q)
-MOVE_TDUMP=if [ -z $(Q)$$(tail -n 1 $(COMPILATION_LOG) | grep 0)$(Q) ]; then $(MOVE_TDUMP_PERL); false; else $(RM) -r $(Q)$(COMPILATION_OUTPUT)$(Q); fi
+MOVE_TDUMP=if [ -z $(Q)$$(tail -1 $(COMPILATION_LOG) | grep 0)$(Q) ]; then $(MOVE_TDUMP_PERL); false; else $(RM) -r $(Q)$(COMPILATION_OUTPUT)$(Q); fi


### PR DESCRIPTION
I don't believe any platforms require the `-n` to be specified on `tail` so this shouldn't impact anything else. I need this change in before I can let https://github.com/AdoptOpenJDK/openjdk-tests/pull/2039 go in (that PR currently hard codes the TKG repo to this branch, so once this PR is merged I can remove that from the other one)

Signed-off-by: Stewart X Addison <sxa@redhat.com>