### PR TITLE
Generate TAP file if there are no tests for the given target

### DIFF
--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -30,6 +30,7 @@ my $jdkImpl = "";
 my $buildList = "";
 my $spec = "";
 my $customTarget = "";
+my $totalCount = 0;
 
 for (my $i = 0; $i < scalar(@ARGV); $i++) {
 	my $arg = $ARGV[$i];
@@ -53,6 +54,8 @@ for (my $i = 0; $i < scalar(@ARGV); $i++) {
 		($spec) = $arg =~ /^\-\-spec=(.*)/;
 	} elsif ($arg =~ /^\-\-customTarget=/) {
 		($customTarget) = $arg =~ /^\-\-customTarget=(.*)/;
+	} elsif ($arg =~ /^\-\-totalCount=/) {
+		($totalCount) = $arg =~ /^\-\-totalCount=(.*)/;
 	}
 }
 
@@ -203,7 +206,8 @@ sub resultReporter {
 	}
 	print "   SKIPPED: $numOfSkipped";
 	print "\n";
-	if ($numOfTotal > 0) {
+        # Only produce TAP file if test results were found, or there are no tests for the given target
+	if (($numOfTotal > 0) || ($totalCount == 0)) {
 		#generate tap output
 		my $dir = dirname($tapFile);
 		if (!(-e $dir and -d $dir)) {

--- a/settings.mk
+++ b/settings.mk
@@ -317,4 +317,4 @@ rmResultFile:
 
 resultsSummary:
 	$(CD) $(Q)$(TEST_ROOT)$(D)TKG$(D)scripts$(Q); \
-	perl $(Q)resultsSum.pl$(Q) --failuremk=$(Q)$(FAILEDTARGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --platFile=$(Q)$(PLATFROMFILE)$(Q) --diagnostic=$(DIAGNOSTICLEVEL) --jdkVersion=$(JDK_VERSION) --jdkImpl=$(JDK_IMPL) --spec=$(SPEC) --buildList=$(BUILD_LIST) --customTarget=$(CUSTOM_TARGET)
+	perl $(Q)resultsSum.pl$(Q) --failuremk=$(Q)$(FAILEDTARGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --platFile=$(Q)$(PLATFROMFILE)$(Q) --diagnostic=$(DIAGNOSTICLEVEL) --jdkVersion=$(JDK_VERSION) --jdkImpl=$(JDK_IMPL) --spec=$(SPEC) --buildList=$(BUILD_LIST) --customTarget=$(CUSTOM_TARGET) --totalCount=$(TOTALCOUNT)


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/TKG/issues/138
If no test targets match the given target, then a TAP file is still produced.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>