### PR TITLE
Also download jtreg-7.5.2+1 and use for Java 26+

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -188,6 +188,13 @@ my %base = (
 		shafn => 'jtreg_7_5_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
+	jtreg_7_5_2_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.2+1.tar.gz',
+		fname => 'jtreg_7_5_2_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.2+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_7_5_2_1.tar.gz.sha256sum.txt',
+		shaalg => '256'
+	},
 	jython => {
 		url => 'https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.2/jython-standalone-2.7.2.jar',
 		fname => 'jython-standalone.jar',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -57,9 +57,16 @@
 					<property name="jtregTar" value="jtreg_7_4_1"/>
 				</then>
 			</elseif>
+			<elseif>
+				<!-- version 25 -->
+				<matches pattern="^25$" string="${JDK_VERSION}"/>
+				<then>
+					<property name="jtregTar" value="jtreg_7_5_1_1"/>
+				</then>
+			</elseif>
 			<else>
-				<!-- versions 25+ -->
-				<property name="jtregTar" value="jtreg_7_5_1_1"/>
+				<!-- versions 26+ -->
+				<property name="jtregTar" value="jtreg_7_5_2_1"/>
 			</else>
 		</if>
 		<echo message="jtreg version used is : ${jtregTar}"/>


### PR DESCRIPTION
Necessitated by openjdk change

* [8357141: Update to use jtreg 7.5.2](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/3cba84f2497cab7f450099b25c3418202a5e1972)

Depends on https://github.com/adoptium/ci-jenkins-pipelines/pull/1230.