### PR TITLE
Updated Maven version

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -206,7 +206,7 @@ my %base = (
 		sha1 => '200da75e67689e8a604ec6fe9a6f55b2c000b6ce'
 	},
 	maven => {
-		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz',
+		url => 'https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
 		sha1 => 'b06edaf09ae03e77d65a9fa6ffc2f6db311b8334'
 	},


### PR DESCRIPTION
Maven version updated to the latest https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz

Related :adoptium/aqa-tests/issues/6460