### PR TITLE
Use jtreg 8+2 for Java 25

### DIFF
--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -58,7 +58,7 @@
 				<!-- version 25 -->
 				<matches pattern="^25$" string="${JDK_VERSION}"/>
 				<then>
-					<property name="jtregTar" value="jtreg_7_5_1_1"/>
+					<property name="jtregTar" value="jtreg_8_2"/>
 				</then>
 			</elseif>
 			<else>


### PR DESCRIPTION
Necessitated by openjdk change:
* [8361950: Update to use jtreg 8](https://github.com/openjdk/jdk25u/commit/9df689f143e43d92bb5d281985ce9c5c514f8803)