### PR TITLE
Removed unused jtreg jar versions

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -174,20 +174,6 @@ my %base = (
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_7_5_1_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz',
-		fname => 'jtreg_7_5_1_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_7_5_1_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
-	jtreg_7_5_2_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.2+1.tar.gz',
-		fname => 'jtreg_7_5_2_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.2+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_7_5_2_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
 	jtreg_8_2 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-8+2.tar.gz',
 		fname => 'jtreg_8_2.tar.gz',


### PR DESCRIPTION
Removed unused jtreg_7_5_2_1 & jtreg_7_5_1_1 jar versions from getDependency.pl

 Closes : https://github.com/adoptium/TKG/issues/762