### PR TITLE
Add retry to getDependencies downloadFile

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -449,7 +449,7 @@ sub downloadFile {
 	}
 
 	my $returnCode = 99;
-        my $download_attempts = 0;
+	my $download_attempts = 0;
 	while ($returnCode != 0 && $download_attempts < 10) {
 		$download_attempts++;
 		print "download attempt $download_attempts for $url\n";


### PR DESCRIPTION
We've seen intermittent problems on some nodes (eg. Solaris) where curl trips up with rc=18 (https://github.com/adoptium/infrastructure/issues/4119).
This PR adds a x10 retry to downloadFile to try and mitigate this.

```
11:50:14      [exec] Starting download third party dependent jars
11:50:14      [exec] --------------------------------------------
11:50:14      [exec] downloading dependent third party jars to /export/home/vagrant/aqa-tests/TKG/../TKG/lib
11:50:14      [exec] downloading -L https://download.dacapobench.org/chopin/dacapo-23.11-MR2-chopin-minimal.zip
11:50:14      [exec] download attempt 1 for -L https://download.dacapobench.org/chopin/dacapo-23.11-MR2-chopin-minimal.zip
11:50:14      [exec] --> file downloaded to /export/home/vagrant/aqa-tests/TKG/../TKG/lib/dacapo.zip
11:50:14      [exec] downloaded dependent third party jars successfully
```

