### PR TITLE
Added jtreg_7_5_1_1 to getDependency files for JDK25

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -174,6 +174,13 @@ my %base = (
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
+	jtreg_7_5_1_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz',
+		fname => 'jtreg_7_5_1_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_7_5_1_1.tar.gz.sha256sum.txt',
+		shaalg => '256'
+	},
 	jtreg_8_2 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-8+2.tar.gz',
 		fname => 'jtreg_8_2.tar.gz',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -58,7 +58,7 @@
 				<!-- version 25 -->
 				<matches pattern="^25$" string="${JDK_VERSION}"/>
 				<then>
-					<property name="jtregTar" value="jtreg_8_2"/>
+					<property name="jtregTar" value="jtreg_7_5_1_1"/>
 				</then>
 			</elseif>
 			<else>


### PR DESCRIPTION
jdk_security1 - java/security/SignedJar/spi-calendar-provider/TestSPISigned - NoSuchFileException

- Replaced jtreg_8_2 with jtreg_7_5_1_1 in getDependecny.xml

- Added jtreg_7_5_1_1 base jar info to getDependency.pl

Related: https://github.com/adoptium/aqa-tests/issues/6708