### PR TITLE
introducing test_java_home to allow for jre testing

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -169,10 +169,11 @@ ifdef JRE_IMAGE
    JRE_COMMAND:=$(Q)$(JRE_IMAGE)$(D)bin$(D)java$(Q)
 endif
 
-JAVA_TO_TEST = $(JAVA_COMMAND)
+TEST_JAVA_HOME:=$(Q)$(TEST_JDK_HOME)$(Q)
 ifeq ($(USE_JRE),1)
-  JAVA_TO_TEST = $(JRE_COMMAND)
+  TEST_JAVA_HOME:=$(Q)$(JRE_IMAGE)$(Q)
 endif
+JAVA_TO_TEST:=$(Q)$(TEST_JAVA_HOME)$(D)bin$(D)java$(Q)
 
 #######################################
 # common dir and jars


### PR DESCRIPTION
related to the https://github.com/adoptium/aqa-tests/issues/6653

JAVA_TO_TEST does not have a counterpart based in the JDK installation in case USE_JRE is set to true
the idea is to have two counterparts:
TEST_JDK_HOME - always point to the JDK installation directory
TEST_JAVA_HOME - always points to the directory of the java that is being tested

second iteration would be to ditch JAVA_TO_TEST variable use in TCK in favor of TEST_JAVA_HOME variable