### PR TITLE
Updating getDependencies to use maven server for downloading asm.jar

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -284,7 +284,7 @@ my %system_jars = (
 	});
 
 my %jars_to_use;
-if ($path =~ /system_lib/ || (exists($ENV["BUILD_TYPE"]) && $ENV["BUILD_TYPE"] eq "systemtest")) {
+if ($path =~ /system_lib/ || (exists($ENV{"BUILD_TYPE"}) && $ENV{"BUILD_TYPE"} eq "systemtest")) {
 	print "System Test jars will be downloaded.\n";
 	%jars_to_use = %system_jars;
 } else {
@@ -317,7 +317,7 @@ if ($task eq "clean") {
 		my $sha1 = $jars_info[$i]{sha1};
 		my $dir = $jars_info[$i]{dir} // "";
 		my $full_dir_path = File::Spec->catdir($path, $dir);
-		if (exists($ENV["BUILD_TYPE"]) && $ENV["BUILD_TYPE"] eq "systemtest") {
+		if (exists($ENV{"BUILD_TYPE"}) && $ENV{"BUILD_TYPE"} eq "systemtest") {
 			$full_dir_path = File::Spec->catdir($path, "systemtest_prereqs" , $dir);
 		}
 		my $url_custom = $customUrl;


### PR DESCRIPTION
Test runs:
- https://ci.adoptium.net/job/systemtest.getDependency/265/ - pass
- https://ci.adoptium.net/job/test.getDependency/2675/ - pass

Linked PR:
- https://github.com/adoptium/aqa-tests/pull/6753
