### PR TITLE
Fetch updated tools jar when gathering systemtest dependencies

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -433,7 +433,6 @@ sub toolsJarDownloader {
 	my ( $dir, $url ) = @_;
 	print "Checksum verification skipped for systemtest_prereqs/tools/tools.jar \n";
 	print "downloading $url \n";
-	print "download attempt 1 for $url \n";
 	qx{_ENCODE_FILE_NEW=BINARY curl -LfsS --create-dirs -o "$dir/jdk8/jdk8.tar.gz" $url 2>&1};
 	qx{tar --directory "$dir/jdk8" -xzf "$dir/jdk8/jdk8.tar.gz" --strip-components 1};
 	qx{cp "$dir/jdk8/lib/tools.jar" "$dir"};


### PR DESCRIPTION
Because the current system recycles the one we currently have, so any file corruption is then permanent.

This fix ensures we get the tools.jar systemtest dependency from a jdk8, as we did prior to the [dependency unification pr](https://github.com/adoptium/TKG/pull/564), which [we switched to last week](https://github.com/adoptium/aqa-tests/pull/6753). 

Tested here: https://ci.adoptium.net/job/systemtest.getDependency/273/