### PR TITLE
Revert "Added jtreg_7_5_1_1 to getDependency files for JDK25"

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -174,13 +174,6 @@ my %base = (
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_7_5_1_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz',
-		fname => 'jtreg_7_5_1_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_7_5_1_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
 	jtreg_8_2 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-8+2.tar.gz',
 		fname => 'jtreg_8_2.tar.gz',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -58,7 +58,7 @@
 				<!-- version 25 -->
 				<matches pattern="^25$" string="${JDK_VERSION}"/>
 				<then>
-					<property name="jtregTar" value="jtreg_7_5_1_1"/>
+					<property name="jtregTar" value="jtreg_8_2"/>
 				</then>
 			</elseif>
 			<else>


### PR DESCRIPTION
Reverts adoptium/TKG#768
Fixes #786 

All sanity.openjdk and extended.openjdk targets fail against any vendor or Temurin builds building off of recent JDK25 tags
```
[2026-01-09T10:46:08.949Z] TESTING:
[2026-01-09T10:46:09.703Z] Error: The testsuite at /home/jenkins/workspace/Test_openjdk25_hs_sanity.openjdk_x86-64_alpine-linux_testList_1/aqa-tests/openjdk/openjdk-jdk/test/jdk requires jtreg version 8+2 or higher and this is jtreg version 7.5.1-dev+1.
```

For any builds that require jtreg 7.5.1.1, can pin to TKG v1.0.11 tag.