### PR TITLE
Adding sha1 hash for mauve.jar

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -277,8 +277,6 @@ my %system_jars = (
 		is_system_test => 1
 	});
 
-
-
 my %jars_to_use;
 if ($path =~ /system_lib/ || (exists($ENV{"BUILD_TYPE"}) && $ENV{"BUILD_TYPE"} eq "systemtest")) {
 	print "System Test jars will be downloaded.\n";


### PR DESCRIPTION
Plus a refactor to remove nesting.

```
for {
  if {
    code 1
  } else {
    code 2
  }
}
```

is now
```
for {
  if {
    code 1
    next
  }
  code 2
}
```

Requires https://github.com/adoptium/aqa-triage-data/pull/9 to be reviewed and merged first, or the sha1 will not match.

Resolves https://github.com/adoptium/aqa-tests/issues/6721