### PR TITLE
Fix z/OS test compilation failure caused by ant-contrib removal in TKG PR #832

### DIFF
--- a/scripts/build_test.xml
+++ b/scripts/build_test.xml
@@ -70,15 +70,13 @@
 	</macrodef>
 
 	<target name="-expand-build-list" if="build.list.needs.expansion">
-		<loadresource property="build.list.expanded">
-			<string value="${BUILD_LIST}"/>
-			<filterchain>
-				<tokenfilter>
-					<replaceregex pattern="([^,]+)" replace="\1/build.xml" flags="g"/>
-				</tokenfilter>
-			</filterchain>
-		</loadresource>
-		<property name="build.list" value="TestConfig/build.xml,${build.list.expanded}"/>
+		<exec executable="perl" outputproperty="build.list.expanded" failonerror="true">
+			<arg value="-e"/>
+			<arg value="my $b = $ENV{BUILD_LIST}; $b =~ s/([^,]+)/$1\/build.xml/g; print 'TestConfig/build.xml,' . $b;"/>
+			<env key="BUILD_LIST" value="${BUILD_LIST}"/>
+		</exec>
+		<property name="build.list" value="${build.list.expanded}"/>
+		<echo>build.list=${build.list}</echo>
 	</target>
 
 	<target name="build" depends="-expand-build-list,stage_test_material" description="using ${JDK_VERSION} to compile the source ">

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -20,19 +20,20 @@
 	</description>
 
 	<target name="getJtregVersion">
-		<!-- versions 8-10, 12-16 -->
-		<condition property="jtregTar" value="jtreg_5_1_b01">
-			<matches pattern="^([89]|1[02-6])$" string="${JDK_VERSION}"/>
-		</condition>
 		<!--
 		# Versions 11, 17 on z/OS need to use jtreg8_2 which uses defaultCharste() to parse TEST.group files.
 		# For more details, see openj9-openjdk-jdk17-zos/issues/928.
+		# IMPORTANT: Platform-specific conditions must come FIRST due to Ant's first-write-wins property behavior.
 		-->
 		<condition property="jtregTar" value="jtreg_8_2">
 			<and>
 				<contains string="${SPEC}" substring="zos"/>
 				<matches pattern="^(11|17)$" string="${JDK_VERSION}"/>
 			</and>
+		</condition>
+		<!-- versions 8-10, 12-16 -->
+		<condition property="jtregTar" value="jtreg_5_1_b01">
+			<matches pattern="^([89]|1[02-6])$" string="${JDK_VERSION}"/>
 		</condition>
 		<!-- versions 11, 18-20, 22-23 -->
 		<condition property="jtregTar" value="jtreg_7_3_1_1">


### PR DESCRIPTION
- move z/OS-specific condition before general JDK version conditions
- loadresource + replaceregex replacement for the ant-contrib <for> loop produces garbled EBCDIC output on z/OS Ant 1.9.9,use perl exec

related: https://github.com/adoptium/TKG/pull/832