### PR TITLE
Avoid perl warning for use of uninitialized value

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -48,7 +48,7 @@ if (! -d $path) {
 
 # define directory path separator
 my $sep = File::Spec->catfile('', '');
-$testDependencyUrl = $ENV{'TEST_DEPENDENCY_URL'} if !defined($testDependencyUrl) || $testDependencyUrl eq '';
+$testDependencyUrl = $ENV{'TEST_DEPENDENCY_URL'} if ($testDependencyUrl eq '' && defined($ENV{'TEST_DEPENDENCY_URL'}));
 
 print "--------------------------------------------\n";
 print "path is set to $path\n";


### PR DESCRIPTION
By default, `url_testDependency` is copied from `TEST_DEPENDENCY_URL` in the environment, which may be undefined.

Testing locally with perl v5.38.2 it complains:
```
[exec] Use of uninitialized value $url_testDependency in string ne at TKG/scripts/getDependencies.pl line 413.
```
This fixes that.