### PR TITLE
 Support MSYS2 shells in addition to Cygwin on Windows

### DIFF
--- a/makeGen.mk
+++ b/makeGen.mk
@@ -41,14 +41,22 @@ include $(CURRENT_DIR)$(D)envSettings.mk
 autoconfig:
 	perl scripts$(D)configure.pl
 
+# MSYS2_ARG_CONV_EXCL=* disables MSYS2's automatic POSIX-to-Win path
+# rewriting of arguments handed to native Win32 binaries. The classpath
+# entries below are already in Windows form (LIB_DIR was cygpath -w'd in
+# the top-level makefile), so the rewriter would only corrupt them. We
+# scope this to the recipes that actually need it instead of exporting
+# globally, because the Apache Ant Unix wrapper script (used by other
+# recipes) relies on the rewriter to translate ANT_HOME's POSIX path.
+# Harmless under Cygwin (the variable is MSYS2-only).
 autogen: autoconfig
-	${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --microArch=$(Q)$(MICROARCH)$(Q) --osLabel=$(Q)$(OS_LABEL)$(Q) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --vendor=$(Q)$(JDK_VENDOR)$(Q) --buildList=${BUILD_LIST} --iterations=$(TKG_ITERATIONS) --aotIterations=$(AOT_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachines=$(NUM_MACHINES) --testTime=$(TEST_TIME) --TRSSURL=$(TRSS_URL) $(OPTS)
+	MSYS2_ARG_CONV_EXCL='*' ${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --microArch=$(Q)$(MICROARCH)$(Q) --osLabel=$(Q)$(OS_LABEL)$(Q) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --vendor=$(Q)$(JDK_VENDOR)$(Q) --buildList=${BUILD_LIST} --iterations=$(TKG_ITERATIONS) --aotIterations=$(AOT_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachines=$(NUM_MACHINES) --testTime=$(TEST_TIME) --TRSSURL=$(TRSS_URL) $(OPTS)
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)
 AUTOGEN_FILES += $(wildcard $(CURRENT_DIR)$(D)machineConfigure.mk)
 AUTOGEN_FILES += $(wildcard $(CURRENT_DIR)$(D)..$(D)*$(D)autoGenTest.mk)
 
 clean:
-	${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE)
+	MSYS2_ARG_CONV_EXCL='*' ${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE)
 
 .PHONY: autoconfig autogen clean

--- a/makeGen.mk
+++ b/makeGen.mk
@@ -41,14 +41,9 @@ include $(CURRENT_DIR)$(D)envSettings.mk
 autoconfig:
 	perl scripts$(D)configure.pl
 
-# MSYS2_ARG_CONV_EXCL=* disables MSYS2's automatic POSIX-to-Win path
-# rewriting of arguments handed to native Win32 binaries. The classpath
-# entries below are already in Windows form (LIB_DIR was cygpath -w'd in
-# the top-level makefile), so the rewriter would only corrupt them. We
-# scope this to the recipes that actually need it instead of exporting
-# globally, because the Apache Ant Unix wrapper script (used by other
-# recipes) relies on the rewriter to translate ANT_HOME's POSIX path.
-# Harmless under Cygwin (the variable is MSYS2-only).
+# MSYS2 rewrites POSIX-looking args before launching native Win32 binaries
+# and mangles the ;-separated classpath. Disable it for this java call only;
+# LIB_DIR is already cygpath -w'd. No-op on Cygwin.
 autogen: autoconfig
 	MSYS2_ARG_CONV_EXCL='*' ${TEST_JDK_HOME}/bin/java -cp $(Q)$(TKG_JAR)$(P)$(JSON_SIMPLE)$(Q) org.testKitGen.MainRunner --mode=$(MODE) --spec=$(SPEC) --microArch=$(Q)$(MICROARCH)$(Q) --osLabel=$(Q)$(OS_LABEL)$(Q) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --vendor=$(Q)$(JDK_VENDOR)$(Q) --buildList=${BUILD_LIST} --iterations=$(TKG_ITERATIONS) --aotIterations=$(AOT_ITERATIONS) --testFlag=$(TEST_FLAG) --testTarget=$(TESTTARGET) --testList=$(TESTLIST) --numOfMachines=$(NUM_MACHINES) --testTime=$(TEST_TIME) --TRSSURL=$(TRSS_URL) $(OPTS)
 

--- a/makefile
+++ b/makefile
@@ -44,6 +44,14 @@ UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
 # Java classpath. cygpath is available in both Cygwin and MSYS2.
 ifneq (,$(filter CYGWIN MSYS MINGW32 MINGW64 UCRT64 CLANGARM64,$(UNAME_OS)))
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
+	# MSYS2 rewrites arguments that look like POSIX paths or path lists
+	# before handing them to native Windows binaries (e.g. java.exe). For
+	# classpath strings like "./bin/foo.jar;C:/path/bar.jar" this can
+	# corrupt the second entry so Java throws NoClassDefFoundError on
+	# classes that live in it. Disable the rewriter; LIB_DIR / TEST_ROOT
+	# are already cygpath -w'd, so paths are passed through verbatim.
+	# Harmless under Cygwin (the variable is MSYS2-only).
+	export MSYS2_ARG_CONV_EXCL := *
 endif
 
 export LIB_DIR:=$(subst \,/,$(LIB_DIR))

--- a/makefile
+++ b/makefile
@@ -38,10 +38,8 @@ endif
 
 UNAME := uname
 UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
-# Under Cygwin and MSYS2 (MSYS/MINGW32/MINGW64/UCRT64/CLANGARM64) the JDK is
-# a native Win32 binary that does not understand POSIX paths like /c/...,
-# so translate LIB_DIR to a Windows-style path before it ends up on the
-# Java classpath. cygpath is available in both Cygwin and MSYS2.
+# Translate LIB_DIR for Cygwin/MSYS2 shells so the native Win32 JDK can
+# read it from the classpath.
 ifneq (,$(filter CYGWIN MSYS MINGW32 MINGW64 UCRT64 CLANGARM64,$(UNAME_OS)))
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
 endif

--- a/makefile
+++ b/makefile
@@ -44,14 +44,6 @@ UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
 # Java classpath. cygpath is available in both Cygwin and MSYS2.
 ifneq (,$(filter CYGWIN MSYS MINGW32 MINGW64 UCRT64 CLANGARM64,$(UNAME_OS)))
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
-	# MSYS2 rewrites arguments that look like POSIX paths or path lists
-	# before handing them to native Windows binaries (e.g. java.exe). For
-	# classpath strings like "./bin/foo.jar;C:/path/bar.jar" this can
-	# corrupt the second entry so Java throws NoClassDefFoundError on
-	# classes that live in it. Disable the rewriter; LIB_DIR / TEST_ROOT
-	# are already cygpath -w'd, so paths are passed through verbatim.
-	# Harmless under Cygwin (the variable is MSYS2-only).
-	export MSYS2_ARG_CONV_EXCL := *
 endif
 
 export LIB_DIR:=$(subst \,/,$(LIB_DIR))

--- a/makefile
+++ b/makefile
@@ -38,7 +38,11 @@ endif
 
 UNAME := uname
 UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
-ifeq ($(findstring CYGWIN,$(UNAME_OS)), CYGWIN)
+# Under Cygwin and MSYS2 (MSYS/MINGW32/MINGW64/UCRT64/CLANGARM64) the JDK is
+# a native Win32 binary that does not understand POSIX paths like /c/...,
+# so translate LIB_DIR to a Windows-style path before it ends up on the
+# Java classpath. cygpath is available in both Cygwin and MSYS2.
+ifneq (,$(filter CYGWIN MSYS MINGW32 MINGW64 UCRT64 CLANGARM64,$(UNAME_OS)))
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
 endif
 

--- a/settings.mk
+++ b/settings.mk
@@ -110,11 +110,14 @@ SCRIPT_SUFFIX=.bat
 PROPS_DIR=props_win
 endif
 
-# Environment variable OSTYPE is set to cygwin if running under cygwin.
+# Environment variable OSTYPE is set to cygwin if running under cygwin,
+# and to msys (or sometimes msys2) under MSYS2/MINGW shells. Treat both
+# as the "Cygwin-style POSIX layer on Windows" case so downstream rules
+# can use ifeq ($(CYGWIN),1) without caring which one is in use.
 ifndef CYGWIN
 	OSTYPE?=$(shell echo $$OSTYPE)
-	ifeq ($(OSTYPE),cygwin)
-			CYGWIN:=1
+	ifneq (,$(filter cygwin msys msys2,$(OSTYPE)))
+		CYGWIN:=1
 	else
 		CYGWIN:=0
 	endif

--- a/settings.mk
+++ b/settings.mk
@@ -110,10 +110,8 @@ SCRIPT_SUFFIX=.bat
 PROPS_DIR=props_win
 endif
 
-# Environment variable OSTYPE is set to cygwin if running under cygwin,
-# and to msys (or sometimes msys2) under MSYS2/MINGW shells. Treat both
-# as the "Cygwin-style POSIX layer on Windows" case so downstream rules
-# can use ifeq ($(CYGWIN),1) without caring which one is in use.
+# OSTYPE is "cygwin" on Cygwin and "msys"/"msys2" on MSYS2 shells; treat
+# all of them as the same POSIX-on-Windows case.
 ifndef CYGWIN
 	OSTYPE?=$(shell echo $$OSTYPE)
 	ifneq (,$(filter cygwin msys msys2,$(OSTYPE)))


### PR DESCRIPTION
 TKG currently treats only Cygwin as the POSIX-on-Windows environment, so when invoked from an MSYS2 shell (MSYS / MINGW64 / UCRT64 / etc.) `make genParallelList` fails with `NoClassDefFoundError: org/json/simple/parser/ParseException`: `LIB_DIR` isn't cygpath-translated, `CYGWIN` isn't set, and MSYS2's arg rewriter mangles the `;`-separated classpath.
 
 This PR:
 - widens the `LIB_DIR` cygpath filter in `makefile` to also match `MSYS`/`MINGW32`/`MINGW64`/`UCRT64`/`CLANGARM64`;
 - sets `CYGWIN:=1` in `settings.mk` when `$OSTYPE` is `msys`/`msys2`, so existing `ifeq ($(CYGWIN),1)` rules apply on MSYS2;
 - prefixes the two `java MainRunner` recipes in `makeGen.mk` with `MSYS2_ARG_CONV_EXCL='*'` so the already-translated classpath is passed through verbatim.
 
 Cygwin behavior is unchanged: the `CYGWIN`/`cygwin` matches still fire, and `MSYS2_ARG_CONV_EXCL` is an MSYS2-only variable that `cygwin1.dll` ignores.