### PR TITLE
Also download jtreg-8.3+1 and use for Java 28+

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -203,6 +203,13 @@ my %base = (
 		shafn => 'jtreg_8_2_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
+	jtreg_8_3_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-8.3+1.tar.gz',
+		fname => 'jtreg_8_3_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-8.3+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_8_3_1.tar.gz.sha256sum.txt',
+		shaalg => '256'
+	},
 	jython => {
 		url => 'https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.2/jython-standalone-2.7.2.jar',
 		fname => 'jython-standalone.jar',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -55,8 +55,12 @@
 		<condition property="jtregTar" value="jtreg_8_1_1">
 			<matches pattern="^26$" string="${JDK_VERSION}"/>
 		</condition>
-		<!-- versions 27+ (default) -->
-		<property name="jtregTar" value="jtreg_8_2_1_1"/>
+		<!-- version 27 -->
+		<condition property="jtregTar" value="jtreg_8_2_1_1">
+			<matches pattern="^27$" string="${JDK_VERSION}"/>
+		</condition>
+		<!-- versions 28+ (default) -->
+		<property name="jtregTar" value="jtreg_8_3_1"/>
 
 		<echo message="jtreg version used is : ${jtregTar}"/>
 


### PR DESCRIPTION
Required by openjdk change:
* [8386844: Update to use jtreg 8.3](https://github.com/openjdk/jdk/commit/b735de6d7190afde0fb056d7c439938439744576)

Depends on https://github.com/adoptium/ci-jenkins-pipelines/pull/1454.