### PR TITLE
Fix z/OS JDK 21/25 test failures by moving BUILD_LIST expansion to Make

### DIFF
--- a/compile.mk
+++ b/compile.mk
@@ -32,13 +32,25 @@ COMPILE_BUILD_LIST := ${BUILD_LIST}
 else
 COMPILE_BUILD_LIST := ${REFINED_BUILD_LIST}
 endif
+
+# Pre-expand BUILD_LIST in Make to avoid charset issues with Ant's <exec>
+# on z/OS JDK 21+.  Pure Make subst — works on all platforms.
+COMMA := ,
+ifeq ($(COMPILE_BUILD_LIST),)
+BUILD_LIST_EXPANDED := */build.xml
+else ifeq ($(COMPILE_BUILD_LIST),NULL)
+BUILD_LIST_EXPANDED := NULL
+else
+BUILD_LIST_EXPANDED := TestConfig/build.xml,$(subst $(COMMA),/build.xml$(COMMA),$(COMPILE_BUILD_LIST))/build.xml
+endif
+
 # TEST_FLAG can be empty, Windows ant does not like empty -D<param> values
 ifneq ($(TEST_FLAG),)
 TEST_FLAG_PARAM := -DTEST_FLAG=$(TEST_FLAG)
 else
 TEST_FLAG_PARAM :=
 endif
-COMPILE_CMD=ant -f scripts$(D)build_test.xml $(Q)-DTEST_ROOT=$(TEST_ROOT)$(Q) $(Q)-DBUILD_ROOT=$(BUILD_ROOT)$(Q) $(Q)-DJDK_VERSION=$(JDK_VERSION)$(Q) $(Q)-DJDK_IMPL=$(JDK_IMPL)$(Q) $(Q)-DJDK_VENDOR=$(JDK_VENDOR)$(Q) $(Q)-DJCL_VERSION=$(JCL_VERSION)$(Q) $(Q)-DBUILD_LIST=${COMPILE_BUILD_LIST}$(Q) $(Q)-DRESOURCES_DIR=${RESOURCES_DIR}$(Q) $(Q)-DSPEC=${SPEC}$(Q) $(Q)-DTEST_JDK_HOME=${TEST_JDK_HOME}$(Q) $(Q)-DJVM_VERSION=$(JVM_VERSION)$(Q) $(Q)-DLIB_DIR=$(LIB_DIR)$(Q) ${TEST_FLAG_PARAM}
+COMPILE_CMD=ant -f scripts$(D)build_test.xml $(Q)-DTEST_ROOT=$(TEST_ROOT)$(Q) $(Q)-DBUILD_ROOT=$(BUILD_ROOT)$(Q) $(Q)-DJDK_VERSION=$(JDK_VERSION)$(Q) $(Q)-DJDK_IMPL=$(JDK_IMPL)$(Q) $(Q)-DJDK_VENDOR=$(JDK_VENDOR)$(Q) $(Q)-DJCL_VERSION=$(JCL_VERSION)$(Q) $(Q)-DBUILD_LIST_EXPANDED=${BUILD_LIST_EXPANDED}$(Q) $(Q)-DRESOURCES_DIR=${RESOURCES_DIR}$(Q) $(Q)-DSPEC=${SPEC}$(Q) $(Q)-DTEST_JDK_HOME=${TEST_JDK_HOME}$(Q) $(Q)-DJVM_VERSION=$(JVM_VERSION)$(Q) $(Q)-DLIB_DIR=$(LIB_DIR)$(Q) ${TEST_FLAG_PARAM}
 
 
 compile:

--- a/scripts/build_test.xml
+++ b/scripts/build_test.xml
@@ -28,17 +28,10 @@
 
 	<import file="./getDependencies.xml"/>
 
-	<!-- Set build.list based on BUILD_LIST value -->
-	<condition property="build.list" value="*/build.xml">
-		<equals arg1="${BUILD_LIST}" arg2=""/>
-	</condition>
-	<condition property="build.list" value="NULL">
-		<equals arg1="${BUILD_LIST}" arg2="NULL"/>
-	</condition>
-	<condition property="build.list.needs.expansion" value="true">
-		<not><isset property="build.list"/></not>
-	</condition>
-	<echo> build.list is ${build.list} </echo>
+	<!-- BUILD_LIST_EXPANDED is pre-expanded by compile.mk (pure Make subst)
+	     to avoid charset issues with Ant exec on z/OS JDK 21+. -->
+	<property name="build.list" value="${BUILD_LIST_EXPANDED}"/>
+	<echo>build.list=${build.list}</echo>
 
 	<macrodef name="addTestenvProperties">
 		<attribute name="repoDir" default="." />
@@ -69,17 +62,7 @@
 		</sequential>
 	</macrodef>
 
-	<target name="-expand-build-list" if="build.list.needs.expansion">
-		<exec executable="perl" outputproperty="build.list.expanded" failonerror="true">
-			<arg value="-e"/>
-			<arg value="my $b = $ENV{BUILD_LIST}; $b =~ s/([^,]+)/$1\/build.xml/g; print 'TestConfig/build.xml,' . $b;"/>
-			<env key="BUILD_LIST" value="${BUILD_LIST}"/>
-		</exec>
-		<property name="build.list" value="${build.list.expanded}"/>
-		<echo>build.list=${build.list}</echo>
-	</target>
-
-	<target name="build" depends="-expand-build-list,stage_test_material" description="using ${JDK_VERSION} to compile the source ">
+	<target name="build" depends="stage_test_material" description="using ${JDK_VERSION} to compile the source ">
 		<subant target="">
 			<property name="build.dir" value="subant1.build" />
 			<property name="not.overloaded" value="not.overloaded" />

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -21,14 +21,12 @@
 
 	<target name="getJtregVersion">
 		<!--
-		# Versions 11, 17 on z/OS need to use jtreg8_2 which uses defaultCharste() to parse TEST.group files.
-		# For more details, see openj9-openjdk-jdk17-zos/issues/928.
-		# IMPORTANT: Platform-specific conditions must come FIRST due to Ant's first-write-wins property behavior.
+		# Versions 11, 17, 21, 25 on z/OS need to use jtreg_8_2 which uses defaultCharset() to parse TEST.group files.
 		-->
 		<condition property="jtregTar" value="jtreg_8_2">
 			<and>
 				<contains string="${SPEC}" substring="zos"/>
-				<matches pattern="^(11|17)$" string="${JDK_VERSION}"/>
+				<matches pattern="^(11|17|21|25)$" string="${JDK_VERSION}"/>
 			</and>
 		</condition>
 		<!-- versions 8-10, 12-16 -->


### PR DESCRIPTION
- On z/OS with JDK 21+, Ant's <exec> of perl for BUILD_LIST expansion produced garbled output due to ASCII/EBCDIC charset mismatch between the JVM (Enhanced ASCII mode) and the perl subprocess. This caused functional test material (including testng.xml) to never be staged, resulting in FileNotFoundException at test runtime.

Fixes: https://github.ibm.com/runtimes/openj9-openjdk-jdk21-zos/issues/985