### PR TITLE
Update jtreg version to 8.3+1 for JDK17,JDK21 & JDK25

### DIFF
--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -40,7 +40,7 @@
 			<matches pattern="^(11|1[89]|2[023])$" string="${JDK_VERSION}"/>
 		</condition>
 		<!-- versions 17, 21 -->
-		<condition property="jtregTar" value="jtreg_7_5_2_1">
+		<condition property="jtregTar" value="jtreg_8_3_1">
 			<matches pattern="^(17|21)$" string="${JDK_VERSION}"/>
 		</condition>
 		<!-- version 24 -->
@@ -48,7 +48,7 @@
 			<matches pattern="^24$" string="${JDK_VERSION}"/>
 		</condition>
 		<!-- version 25 -->
-		<condition property="jtregTar" value="jtreg_8_2">
+		<condition property="jtregTar" value="jtreg_8_3_1">
 			<matches pattern="^25$" string="${JDK_VERSION}"/>
 		</condition>
 		<!-- version 26 -->


### PR DESCRIPTION
Modify jtreg version of jdk17,jdk21 &jdk25 to 8.3+1

Related : https://github.ibm.com/runtimes/automation/issues/1083

Signed-off-by : Amrutha Kanhirathingal <Amrutha.Kanhirathingal@ibm.com>