### PR TITLE
fix(getDependencies): stop system test jars from being re-downloaded on every run

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -751,12 +751,11 @@ if ($task eq "clean") {
 				# if the sha file exists locally, parse it and get the expected sha
 				if (-e $shafn) {
 					$expectedsha = getShaFromFile($shafn, $fn);
+				} elsif ($shaurl) {
+					downloadFile($shaurl, $shafn);
+					$expectedsha = getShaFromFile($shafn, $fn);
 				}
 			}
-			# Note: do NOT fetch shaurl here. The remote sidecar is only fetched
-			# after a download (below) so we never make a network call just to
-			# decide whether to skip. Warm-cache reuse is handled by the inline
-			# sha256/sha1 value or a locally present sidecar file.
 		}
 
 		if ($expectedsha && $digest eq $expectedsha) {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -709,14 +709,14 @@ if ($task eq "clean") {
 		# if url_testDependency is provided, use url_testDependency and reset $url and $shaurl
 		if ($url_testDependency ne "") {
 			if (defined $jars_info[$i]{is_system_test} && $jars_info[$i]{is_system_test} == 1) {
-				$url_testDependency =~ s/test.getDependency/systemtest.getDependency/;
+				$url_testDependency =~ s/test\.getDependency/systemtest.getDependency/;
 				$url_testDependency .= "systemtest_prereqs/";
 				$url_testDependency .= $jars_info[$i]{dir};
 			}
 
 			# Ensure exactly one slash between the base URL and the filename,
 			# regardless of whether the caller provided a trailing slash.
-			$url_testDependency =~ s/\/$//;
+			$url_testDependency =~ s/\/+$//;
 
 			$url = "$url_testDependency/$jars_info[$i]{fname}";
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -707,8 +707,11 @@ if ($task eq "clean") {
 				$url_testDependency =~ s/test.getDependency/systemtest.getDependency/;
 				$url_testDependency .= "systemtest_prereqs/";
 				$url_testDependency .= $jars_info[$i]{dir};
-				$url_testDependency .= '/' unless $url_testDependency =~ /\/$/;
 			}
+
+			# Ensure exactly one slash between the base URL and the filename,
+			# regardless of whether the caller provided a trailing slash.
+			$url_testDependency =~ s/\/$//;
 
 			$url = "$url_testDependency/$jars_info[$i]{fname}";
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -595,7 +595,8 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar',
 		dir => 'apache-ant/lib',
 		fname => 'ant-launcher.jar',
-		sha1 => 'c99d018fcc43a1540e465b9a097508b19075198c',
+		sha1 => '28cfb70020dfdb9e4e261ceed16c43aed715c1d11390e3ddbecda1e548253168',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	asm => {
@@ -609,35 +610,40 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/netbeans/lib/cvsclient/20060125/cvsclient-20060125.jar',
 		dir => 'cvsclient',
 		fname => 'org-netbeans-lib-cvsclient.jar',
-		sha1 => 'cc80bd0085c79be7ed332cbdc1db77498bff1fda',
+		sha1 => '89baed753b393d5074d4b9b4ba4b9692af6cd0713199998fb294b99942c820a3',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	hamcrest_core => {
 		url => 'https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar',
 		dir => 'junit',
 		fname => 'hamcrest-core.jar',
-		sha1 => '42a25dc3219429f0e5d060061f71acb49bf010a0',
+		sha1 => '66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	junit => {
 		url => 'https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar',
 		dir => 'junit',
 		fname => 'junit.jar',
-		sha1 => '2973d150c0dc1fefe998f834810d68f278ea58ec',
+		sha1 => '59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	log4j_api => {
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-api.jar',
-		sha1 => '4a5aa7e55a29391c6f66e0b259d5189aa11e45d0',
+		sha1 => 'c8c33e7e8e05496dae69cf0caac8c3092cffd937a164526e92922d2d566d0a55',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	log4j_core => {
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-core.jar',
-		sha1 => 'ba55c13d7ac2fd44df9cc8074455719a33f375b9',
+		sha1 => '419a8512895971b7b4f4f33e620d361254e5c9552b904b0474b09ddd4a6a220b',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	mauve => {
@@ -709,7 +715,7 @@ if ($task eq "clean") {
 		# if url_testDependency is provided, use url_testDependency and reset $url and $shaurl
 		if ($url_testDependency ne "") {
 			if (defined $jars_info[$i]{is_system_test} && $jars_info[$i]{is_system_test} == 1) {
-				$url_testDependency =~ s/test\.getDependency/systemtest.getDependency/;
+				$url_testDependency =~ s/test.getDependency/systemtest.getDependency/;
 				$url_testDependency .= "systemtest_prereqs/";
 				$url_testDependency .= $jars_info[$i]{dir};
 			}
@@ -737,33 +743,26 @@ if ($task eq "clean") {
 		if (!$expectedsha) {
 			if (defined $shafn && $shafn ne '') {
 				$shafn = $path . $sep . $shafn;
-				# if the sha file exists, parse the file and get the expected sha
+				# if the sha file exists locally, parse it and get the expected sha
 				if (-e $shafn) {
 					$expectedsha = getShaFromFile($shafn, $fn);
 				}
 			}
-
-			# if expectedsha is not set above and shaurl is provided, download the sha file
-			# and parse the file to get the expected sha
-			if (!$expectedsha && $shaurl) {
-				downloadFile($shaurl, $shafn);
-				$expectedsha = getShaFromFile($shafn, $fn);
-			}
-		}
-
-		if ($expectedsha && $digest eq $expectedsha) {
-			print "$filename exists with correct hash, not downloading\n";
-			next;
 		}
 
 		my $ignoreChecksum = (!defined $sha1 || $sha1 eq '') && (!defined $shaurl || $shaurl eq '');
-		# download the dependent third party jar
 
+		# If file exists and SHA matches, skip download entirely.
+		# If no checksum is available and the file is present, skip download.
+		if (-e $filename && $expectedsha && $digest eq $expectedsha) {
+			print "$filename exists with correct hash, not downloading\n";
+			next;
+		}
 		if ($ignoreChecksum && -e $filename) {
 			print "$filename exists, not downloading.\n";
 			next;
 		}
-		# download the dependent third party jar
+
 		downloadFile($url, $filename);
 
 		# If shaurl is provided, download the sha file to get the expected checksum
@@ -789,6 +788,8 @@ if ($task eq "clean") {
 				print "Please delete $filename and rerun the program!";
 				die "ERROR: sha checksum error.\n";
 			}
+		} elsif ($ignoreChecksum) {
+			print "Checksum verification skipped for $filename\n";
 		}
 	}
 	print "downloaded dependent third party jars successfully\n";

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -595,6 +595,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar',
 		dir => 'apache-ant/lib',
 		fname => 'ant-launcher.jar',
+		sha1 => 'c99d018fcc43a1540e465b9a097508b19075198c',
 		is_system_test => 1
 	},
 	asm => {
@@ -608,30 +609,35 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/netbeans/lib/cvsclient/20060125/cvsclient-20060125.jar',
 		dir => 'cvsclient',
 		fname => 'org-netbeans-lib-cvsclient.jar',
+		sha1 => 'cc80bd0085c79be7ed332cbdc1db77498bff1fda',
 		is_system_test => 1
 	},
 	hamcrest_core => {
 		url => 'https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar',
 		dir => 'junit',
 		fname => 'hamcrest-core.jar',
+		sha1 => '42a25dc3219429f0e5d060061f71acb49bf010a0',
 		is_system_test => 1
 	},
 	junit => {
 		url => 'https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar',
 		dir => 'junit',
 		fname => 'junit.jar',
+		sha1 => '2973d150c0dc1fefe998f834810d68f278ea58ec',
 		is_system_test => 1
 	},
 	log4j_api => {
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-api.jar',
+		sha1 => '4a5aa7e55a29391c6f66e0b259d5189aa11e45d0',
 		is_system_test => 1
 	},
 	log4j_core => {
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-core.jar',
+		sha1 => 'ba55c13d7ac2fd44df9cc8074455719a33f375b9',
 		is_system_test => 1
 	},
 	mauve => {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -753,13 +753,10 @@ if ($task eq "clean") {
 					$expectedsha = getShaFromFile($shafn, $fn);
 				}
 			}
-
-			# if expectedsha is not set above and shaurl is provided, download the sha file
-			# and parse the file to get the expected sha so an existing valid file can be reused
-			if (!$expectedsha && $shaurl) {
-				downloadFile($shaurl, $shafn);
-				$expectedsha = getShaFromFile($shafn, $fn);
-			}
+			# Note: do NOT fetch shaurl here. The remote sidecar is only fetched
+			# after a download (below) so we never make a network call just to
+			# decide whether to skip. Warm-cache reuse is handled by the inline
+			# sha256/sha1 value or a locally present sidecar file.
 		}
 
 		if ($expectedsha && $digest eq $expectedsha) {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -239,343 +239,343 @@ my %base = (
 	icu4j_61_1 => {
 		url => 'https://repo1.maven.org/maven2/com/ibm/icu/icu4j/61.1/icu4j-61.1.jar',
 		fname => 'icu4j-61_1.jar',
-		sha1 => '55c98eb1838b2a4bb9a07dc36bd378532d64d0cdcb7ceee914236866a7de4464',
+		sha256 => '55c98eb1838b2a4bb9a07dc36bd378532d64d0cdcb7ceee914236866a7de4464',
 		shaalg => '256'
 	},
 	icu4j_localespi_61_1 => {
 		url => 'https://repo1.maven.org/maven2/com/ibm/icu/icu4j-localespi/61.1/icu4j-localespi-61.1.jar',
 		fname => 'icu4j-localespi-61_1.jar',
-		sha1 => '99691e7562bcb211fc247ea27d4abf94486c5f373907da71a17bb358d97829b1',
+		sha256 => '99691e7562bcb211fc247ea27d4abf94486c5f373907da71a17bb358d97829b1',
 		shaalg => '256'
 	},
 	unicode_gb18030_2022 => {
 		url => 'https://www.unicode.org/Public/mappings/iso10646/GB18030-2022.txt',
 		fname => 'GB18030-2022.txt',
-		sha1 => '80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880',
+		sha256 => '80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880',
 		shaalg => '256'
 	},
 	unicode_unihan_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/Unihan.zip',
 		fname => 'Unihan-17.0.0.zip',
-		sha1 => 'f7a48b2b545acfaa77b2d607ae28747404ce02baefee16396c5d2d7a8ef34b5e',
+		sha256 => 'f7a48b2b545acfaa77b2d607ae28747404ce02baefee16396c5d2d7a8ef34b5e',
 		shaalg => '256'
 	},
 	unicode_unihan_16_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/16.0.0/Unihan.zip',
 		fname => 'Unihan-16.0.0.zip',
-		sha1 => 'b8f000df69de7828d21326a2ffea462b04bc7560022989f7cc704f10521ef3e0',
+		sha256 => 'b8f000df69de7828d21326a2ffea462b04bc7560022989f7cc704f10521ef3e0',
 		shaalg => '256'
 	},
 	unicode_unihan_15_1_0 => {
 		url => 'https://www.unicode.org/Public/zipped/15.1.0/Unihan.zip',
 		fname => 'Unihan-15.1.0.zip',
-		sha1 => 'a0226610e324bcf784ac380e11f4cbf533ee1e6b3d028b0991bf8c0dc3f85853',
+		sha256 => 'a0226610e324bcf784ac380e11f4cbf533ee1e6b3d028b0991bf8c0dc3f85853',
 		shaalg => '256'
 	},
 	unicode_unihan_15_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/15.0.0/Unihan.zip',
 		fname => 'Unihan-15.0.0.zip',
-		sha1 => '24b154691fc97cb44267b925d62064297086b3f896b57a8181c7b6d42702a026',
+		sha256 => '24b154691fc97cb44267b925d62064297086b3f896b57a8181c7b6d42702a026',
 		shaalg => '256'
 	},
 	unicode_unihan_14_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/14.0.0/Unihan.zip',
 		fname => 'Unihan-14.0.0.zip',
-		sha1 => '2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d',
+		sha256 => '2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d',
 		shaalg => '256'
 	},
 	unicode_unihan_13_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/13.0.0/Unihan.zip',
 		fname => 'Unihan-13.0.0.zip',
-		sha1 => 'e380194c4835ad85aa50e8750a58c1f605dbfc4aba9e3e3b0ca25b9530c02f64',
+		sha256 => 'e380194c4835ad85aa50e8750a58c1f605dbfc4aba9e3e3b0ca25b9530c02f64',
 		shaalg => '256'
 	},
 	unicode_unihan_12_1_0 => {
 		url => 'https://www.unicode.org/Public/zipped/12.1.0/Unihan.zip',
 		fname => 'Unihan-12.1.0.zip',
-		sha1 => '6e4553f3b5fffe0d312df324d020ef1278d9595932ae03f4e8a2d427de83cdcd',
+		sha256 => '6e4553f3b5fffe0d312df324d020ef1278d9595932ae03f4e8a2d427de83cdcd',
 		shaalg => '256'
 	},
 	unicode_unihan_11_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/11.0.0/Unihan.zip',
 		fname => 'Unihan-11.0.0.zip',
-		sha1 => '72079d9d64acd452e1496f67b975a82a989f0023f37aed092c51cf13567fc833',
+		sha256 => '72079d9d64acd452e1496f67b975a82a989f0023f37aed092c51cf13567fc833',
 		shaalg => '256'
 	},
 	unicode_unihan_10_0_0 => {
 		url => 'https://www.unicode.org/Public/zipped/10.0.0/Unihan.zip',
 		fname => 'Unihan-10.0.0.zip',
-		sha1 => '01232063a8529636cf155ba7a1dbad329cb2e63acde83a3d607b5eafa8f933a5',
+		sha256 => '01232063a8529636cf155ba7a1dbad329cb2e63acde83a3d607b5eafa8f933a5',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-17.0.0.txt',
-		sha1 => '2e1efc1dcb59c575eedf5ccae60f95229f706ee6d031835247d843c11d96470c',
+		sha256 => '2e1efc1dcb59c575eedf5ccae60f95229f706ee6d031835247d843c11d96470c',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-17.0.0.txt',
-		sha1 => 'c0edefaf1a19771e830a82735472716af6bf3c3975f6c2a23ffbe2580fbbcb15',
+		sha256 => 'c0edefaf1a19771e830a82735472716af6bf3c3975f6c2a23ffbe2580fbbcb15',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-17.0.0.txt',
-		sha1 => '9f5e50d3abaee7d6ce09480f325c706f485ae3240912527e651954d2d6b035bf',
+		sha256 => '9f5e50d3abaee7d6ce09480f325c706f485ae3240912527e651954d2d6b035bf',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-17.0.0.txt',
-		sha1 => '5019ffd530751a741900c849c0e010332f142a3612234639bd200b82138a87db',
+		sha256 => '5019ffd530751a741900c849c0e010332f142a3612234639bd200b82138a87db',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_17_0_0 => {
 		url => 'https://www.unicode.org/Public/17.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-17.0.0.txt',
-		sha1 => '64e9a5f76f7a1e8b5a47d6a1f9a26522a251208f5276bdfa1559dac7cf2e827a',
+		sha256 => '64e9a5f76f7a1e8b5a47d6a1f9a26522a251208f5276bdfa1559dac7cf2e827a',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_16_0_0 => {
 		url => 'https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-16.0.0.txt',
-		sha1 => 'ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f',
+		sha256 => 'ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_16_0_0 => {
 		url => 'https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-16.0.0.txt',
-		sha1 => 'f3907b395d410f1b97342292ca6bc83dd12eb4b205f2a0c48efdef99e517d7b0',
+		sha256 => 'f3907b395d410f1b97342292ca6bc83dd12eb4b205f2a0c48efdef99e517d7b0',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_16_0_0 => {
 		url => 'https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-16.0.0.txt',
-		sha1 => '9e88f0a677df47311106340be8ede2ecdacd9c1c931831218d2be6d5508e0039',
+		sha256 => '9e88f0a677df47311106340be8ede2ecdacd9c1c931831218d2be6d5508e0039',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_16_0_0 => {
 		url => 'https://www.unicode.org/Public/16.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-16.0.0.txt',
-		sha1 => 'd811971453e7075e1ad56fb1b301eece5aa80757b81f6156e74a1bfb3ae5ceb1',
+		sha256 => 'd811971453e7075e1ad56fb1b301eece5aa80757b81f6156e74a1bfb3ae5ceb1',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_16_0_0 => {
 		url => 'https://www.unicode.org/Public/16.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-16.0.0.txt',
-		sha1 => '440fd3e5460b9bfe31da67b6f923992e1989d31fe2ed91e091c4b8f8e2620bf9',
+		sha256 => '440fd3e5460b9bfe31da67b6f923992e1989d31fe2ed91e091c4b8f8e2620bf9',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_15_1_0 => {
 		url => 'https://www.unicode.org/Public/15.1.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-15.1.0.txt',
-		sha1 => '2fc713e6a31a87c4850a37fe2caffa4218180fadb5de86b43a143ddb4581fb86',
+		sha256 => '2fc713e6a31a87c4850a37fe2caffa4218180fadb5de86b43a143ddb4581fb86',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_15_1_0 => {
 		url => 'https://www.unicode.org/Public/15.1.0/ucd/Blocks.txt',
 		fname => 'Blocks-15.1.0.txt',
-		sha1 => '443ee0524a775bf021777c296f5b591b5611c8aef6bc922887d27b0bc13892b5',
+		sha256 => '443ee0524a775bf021777c296f5b591b5611c8aef6bc922887d27b0bc13892b5',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_15_1_0 => {
 		url => 'https://www.unicode.org/Public/15.1.0/ucd/Scripts.txt',
 		fname => 'Scripts-15.1.0.txt',
-		sha1 => '0eacb65169ae6eb1d399cd70826b3da15fff19f6f586eecf819b70c83b1d9b32',
+		sha256 => '0eacb65169ae6eb1d399cd70826b3da15fff19f6f586eecf819b70c83b1d9b32',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_15_1_0 => {
 		url => 'https://www.unicode.org/Public/15.1.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-15.1.0.txt',
-		sha1 => '871238e37e3be0696ec2bd0891119a041b052da1a84485eda05a5438724b223e',
+		sha256 => '871238e37e3be0696ec2bd0891119a041b052da1a84485eda05a5438724b223e',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_15_1_0 => {
 		url => 'https://www.unicode.org/Public/15.1.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-15.1.0.txt',
-		sha1 => '4b7411fc592c4985e5f03643aa0bddfdfd45250ff1790d358926614d20e37652',
+		sha256 => '4b7411fc592c4985e5f03643aa0bddfdfd45250ff1790d358926614d20e37652',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_15_0_0 => {
 		url => 'https://www.unicode.org/Public/15.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-15.0.0.txt',
-		sha1 => '806e9aed65037197f1ec85e12be6e8cd870fc5608b4de0fffd990f689f376a73',
+		sha256 => '806e9aed65037197f1ec85e12be6e8cd870fc5608b4de0fffd990f689f376a73',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_15_0_0 => {
 		url => 'https://www.unicode.org/Public/15.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-15.0.0.txt',
-		sha1 => '529dc5d0f6386d52f2f56e004bbfab48ce2d587eea9d38ba546c4052491bd820',
+		sha256 => '529dc5d0f6386d52f2f56e004bbfab48ce2d587eea9d38ba546c4052491bd820',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_15_0_0 => {
 		url => 'https://www.unicode.org/Public/15.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-15.0.0.txt',
-		sha1 => 'cca85d830f46aece2e7c1459ef1249993dca8f2e46d51e869255be140d7ea4b0',
+		sha256 => 'cca85d830f46aece2e7c1459ef1249993dca8f2e46d51e869255be140d7ea4b0',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_15_0_0 => {
 		url => 'https://www.unicode.org/Public/15.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-15.0.0.txt',
-		sha1 => 'fb9ac8cc154a80cad6caac9897af55a4e75176af6f4e2bb6edc2bf8b1d57f326',
+		sha256 => 'fb9ac8cc154a80cad6caac9897af55a4e75176af6f4e2bb6edc2bf8b1d57f326',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_15_0_0 => {
 		url => 'https://www.unicode.org/Public/15.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-15.0.0.txt',
-		sha1 => '13a7666843abea5c6b7eb8c057c57ab9bb2ba96cfc936e204224dd67d71cafad',
+		sha256 => '13a7666843abea5c6b7eb8c057c57ab9bb2ba96cfc936e204224dd67d71cafad',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_14_0_0 => {
 		url => 'https://www.unicode.org/Public/14.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-14.0.0.txt',
-		sha1 => '36018e68657fdcb3485f636630ffe8c8532e01c977703d2803f5b89d6c5feafb',
+		sha256 => '36018e68657fdcb3485f636630ffe8c8532e01c977703d2803f5b89d6c5feafb',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_14_0_0 => {
 		url => 'https://www.unicode.org/Public/14.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-14.0.0.txt',
-		sha1 => '598870dddef7b34b5a972916528c456aff2765b79cd4f9647fb58ceb767e7f17',
+		sha256 => '598870dddef7b34b5a972916528c456aff2765b79cd4f9647fb58ceb767e7f17',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_14_0_0 => {
 		url => 'https://www.unicode.org/Public/14.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-14.0.0.txt',
-		sha1 => '52db475c4ec445e73b0b16915448c357614946ad7062843c563e00d7535c6510',
+		sha256 => '52db475c4ec445e73b0b16915448c357614946ad7062843c563e00d7535c6510',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_14_0_0 => {
 		url => 'https://www.unicode.org/Public/14.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-14.0.0.txt',
-		sha1 => '7cb30cc2abe6c29c292b99095865d379ce1213045c78c4ff59c7e9391bbe2331',
+		sha256 => '7cb30cc2abe6c29c292b99095865d379ce1213045c78c4ff59c7e9391bbe2331',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_14_0_0 => {
 		url => 'https://www.unicode.org/Public/14.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-14.0.0.txt',
-		sha1 => 'eb755757e20b72b330b2948df3cf2ff7adb0e31bb060140dc09dafb132ace2cd',
+		sha256 => 'eb755757e20b72b330b2948df3cf2ff7adb0e31bb060140dc09dafb132ace2cd',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_13_0_0 => {
 		url => 'https://www.unicode.org/Public/13.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-13.0.0.txt',
-		sha1 => 'bdbffbbfc8ad4d3a6d01b5891510458f3d36f7170422af4ea2bed3211a73e8bb',
+		sha256 => 'bdbffbbfc8ad4d3a6d01b5891510458f3d36f7170422af4ea2bed3211a73e8bb',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_13_0_0 => {
 		url => 'https://www.unicode.org/Public/13.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-13.0.0.txt',
-		sha1 => '81a82b6a9fcf1a9c12f588d7a1decd73a9afdc4cac95b0eb7e576e7942d6c19f',
+		sha256 => '81a82b6a9fcf1a9c12f588d7a1decd73a9afdc4cac95b0eb7e576e7942d6c19f',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_13_0_0 => {
 		url => 'https://www.unicode.org/Public/13.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-13.0.0.txt',
-		sha1 => '9a5ed1ec9b5f0d7147e9371ad792ab39203611af7637cff2aa4a5c663b172cde',
+		sha256 => '9a5ed1ec9b5f0d7147e9371ad792ab39203611af7637cff2aa4a5c663b172cde',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_13_0_0 => {
 		url => 'https://www.unicode.org/Public/13.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-13.0.0.txt',
-		sha1 => 'd60ee55dd9169444652e48d337109cc814ecc59a9d3122eedddf7de388f2e01d',
+		sha256 => 'd60ee55dd9169444652e48d337109cc814ecc59a9d3122eedddf7de388f2e01d',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_13_0_0 => {
 		url => 'https://www.unicode.org/Public/13.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-13.0.0.txt',
-		sha1 => '6b3902e9268cd843fe65cbdea992108c9528343ec0679f800b96f356bb553e5a',
+		sha256 => '6b3902e9268cd843fe65cbdea992108c9528343ec0679f800b96f356bb553e5a',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_12_1_0 => {
 		url => 'https://www.unicode.org/Public/12.1.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-12.1.0.txt',
-		sha1 => '93ab1acd8fd9d450463b50ae77eab151a7cda48f98b25b56baed8070f80fc936',
+		sha256 => '93ab1acd8fd9d450463b50ae77eab151a7cda48f98b25b56baed8070f80fc936',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_12_1_0 => {
 		url => 'https://www.unicode.org/Public/12.1.0/ucd/Blocks.txt',
 		fname => 'Blocks-12.1.0.txt',
-		sha1 => 'a28b205afe8625fffdb6544a5fe14cf02b91493d9900f07820fa2102a17548f7',
+		sha256 => 'a28b205afe8625fffdb6544a5fe14cf02b91493d9900f07820fa2102a17548f7',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_12_1_0 => {
 		url => 'https://www.unicode.org/Public/12.1.0/ucd/Scripts.txt',
 		fname => 'Scripts-12.1.0.txt',
-		sha1 => 'e6313a8edfd24f36c7a006fbcf1d1b7245b5dd009c6dde80441f0da08b822c43',
+		sha256 => 'e6313a8edfd24f36c7a006fbcf1d1b7245b5dd009c6dde80441f0da08b822c43',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_12_1_0 => {
 		url => 'https://www.unicode.org/Public/12.1.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-12.1.0.txt',
-		sha1 => '8cabbd6293c88ca05f0b601ade0fd16978ac670a077c0e0f419986ddd33c6941',
+		sha256 => '8cabbd6293c88ca05f0b601ade0fd16978ac670a077c0e0f419986ddd33c6941',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_12_1_0 => {
 		url => 'https://www.unicode.org/Public/12.1.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-12.1.0.txt',
-		sha1 => 'efce54f7c715a332c19b3d14c6a0eea30c6cde91caf6ff0d21c755be933736f4',
+		sha256 => 'efce54f7c715a332c19b3d14c6a0eea30c6cde91caf6ff0d21c755be933736f4',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_11_0_0 => {
 		url => 'https://www.unicode.org/Public/11.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-11.0.0.txt',
-		sha1 => '4997a3196eb79b4d0d6b8384560f6aeb46a062693f0abd5ba736abbff7976099',
+		sha256 => '4997a3196eb79b4d0d6b8384560f6aeb46a062693f0abd5ba736abbff7976099',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_11_0_0 => {
 		url => 'https://www.unicode.org/Public/11.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-11.0.0.txt',
-		sha1 => '0b457b66c788a97c8521e265f0b793d4ed911356d39eb61029f9cef8554cd052',
+		sha256 => '0b457b66c788a97c8521e265f0b793d4ed911356d39eb61029f9cef8554cd052',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_11_0_0 => {
 		url => 'https://www.unicode.org/Public/11.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-11.0.0.txt',
-		sha1 => 'e9f3c0aa3c4f892b589c809cf4ae051a39921417cda6fefdbe43717b92db76d5',
+		sha256 => 'e9f3c0aa3c4f892b589c809cf4ae051a39921417cda6fefdbe43717b92db76d5',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_11_0_0 => {
 		url => 'https://www.unicode.org/Public/11.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-11.0.0.txt',
-		sha1 => '0fdfc17093dd5482f8089cb11dcd936abdba34c4c9c324e5b8a4e5d8f943f6d3',
+		sha256 => '0fdfc17093dd5482f8089cb11dcd936abdba34c4c9c324e5b8a4e5d8f943f6d3',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_11_0_0 => {
 		url => 'https://www.unicode.org/Public/11.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-11.0.0.txt',
-		sha1 => '2a9cb9afe6a36a1a73ce2cedb540abd3fbf29f6afcda702d07fcbf561162a17a',
+		sha256 => '2a9cb9afe6a36a1a73ce2cedb540abd3fbf29f6afcda702d07fcbf561162a17a',
 		shaalg => '256'
 	},
 	unicode_ucd_unicodedata_10_0_0 => {
 		url => 'https://www.unicode.org/Public/10.0.0/ucd/UnicodeData.txt',
 		fname => 'UnicodeData-10.0.0.txt',
-		sha1 => '52423e4d7492167b62f518f68d54db88930abbbff7f11edfcaec8f726498cab1',
+		sha256 => '52423e4d7492167b62f518f68d54db88930abbbff7f11edfcaec8f726498cab1',
 		shaalg => '256'
 	},
 	unicode_ucd_blocks_10_0_0 => {
 		url => 'https://www.unicode.org/Public/10.0.0/ucd/Blocks.txt',
 		fname => 'Blocks-10.0.0.txt',
-		sha1 => '5ae1649a42ed8ae8cb885af79563f00a9ae17e602405a56ed8aca214da14eea7',
+		sha256 => '5ae1649a42ed8ae8cb885af79563f00a9ae17e602405a56ed8aca214da14eea7',
 		shaalg => '256'
 	},
 	unicode_ucd_scripts_10_0_0 => {
 		url => 'https://www.unicode.org/Public/10.0.0/ucd/Scripts.txt',
 		fname => 'Scripts-10.0.0.txt',
-		sha1 => 'd02e24e4c516e9090b6bc9c2d2c8f4c89510b6ed8c5e859d0a861b0dc5cf372d',
+		sha256 => 'd02e24e4c516e9090b6bc9c2d2c8f4c89510b6ed8c5e859d0a861b0dc5cf372d',
 		shaalg => '256'
 	},
 	unicode_ucd_normalization_10_0_0 => {
 		url => 'https://www.unicode.org/Public/10.0.0/ucd/NormalizationTest.txt',
 		fname => 'NormalizationTest-10.0.0.txt',
-		sha1 => '05307ec5bcbd3af3f1687b4da5443658bf72644a5cd4106c20d12b0a3a0818c9',
+		sha256 => '05307ec5bcbd3af3f1687b4da5443658bf72644a5cd4106c20d12b0a3a0818c9',
 		shaalg => '256'
 	},
 	unicode_ucd_propvalaliases_10_0_0 => {
 		url => 'https://www.unicode.org/Public/10.0.0/ucd/PropertyValueAliases.txt',
 		fname => 'PropertyValueAliases-10.0.0.txt',
-		sha1 => 'a6b0467c3cc7aa4e57d4e5cc7f6e9562b79cf4426dfe438517c28b368ed3e673',
+		sha256 => 'a6b0467c3cc7aa4e57d4e5cc7f6e9562b79cf4426dfe438517c28b368ed3e673',
 		shaalg => '256'
 	});
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -714,10 +714,6 @@ if ($task eq "clean") {
 				$url_testDependency .= $jars_info[$i]{dir};
 			}
 
-			# Ensure exactly one slash between the base URL and the filename,
-			# regardless of whether the caller provided a trailing slash.
-			$url_testDependency =~ s/\/+$//;
-
 			$url = "$url_testDependency/$jars_info[$i]{fname}";
 
 			if (defined $shaurl && $shaurl ne '') {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -696,7 +696,6 @@ if ($task eq "clean") {
 			}
 		}
 		my $url_testDependency = $testDependencyUrl;
-		my $third_party_url = $url;
 
 		if (!-d $full_dir_path) {
 			make_path($full_dir_path, {chmod => 0755, verbose => 1}) or die "Failed to create directory: $full_dir_path: $!";
@@ -768,60 +767,12 @@ if ($task eq "clean") {
 			print "$filename exists, not downloading.\n";
 			next;
 		}
-		my $download_success = 0;
-		my $sha_verified = 0;
-		my $has_testDependency_url = ($url_testDependency ne "" && $url ne $third_party_url);
+		# download the dependent third party jar
+		downloadFile($url, $filename);
 
-		# Try download from URL (testDependency or third-party)
-		eval {
-			downloadFile($url, $filename);
-			$download_success = 1;
-		};
-
-		# If download succeeded, verify SHA
-		if ($download_success && !$ignoreChecksum) {
-			my $expectedsha_check = $expectedsha;
-			if (!$expectedsha_check && $shaurl) {
-				eval {
-					downloadFile($shaurl, $shafn);
-					$expectedsha_check = getShaFromFile($shafn, $fn);
-				};
-			}
-
-			if ($expectedsha_check) {
-				$sha = Digest::SHA->new($shaalg);
-				$sha->addfile($filename);
-				$digest = $sha->hexdigest;
-				if ($digest eq $expectedsha_check) {
-					$sha_verified = 1;
-					print "SHA verification passed for $filename\n";
-				} elsif ($has_testDependency_url) {
-					print "Warning: SHA mismatch for $filename from testDependency URL\n";
-					print "Expected: $expectedsha_check, Got: $digest\n";
-					$download_success = 0;  # Mark as failed to trigger fallback
-					unlink $filename;  # Delete bad file
-				}
-			}
-		}
-
-		# Fall back to third-party URL if testDependency URL failed or had SHA mismatch
-		if (!$download_success) {
-			print "Falling back to third-party URL: $third_party_url\n";
-			eval {
-				downloadFile($third_party_url, $filename);
-				$download_success = 1;
-			};
-			if (!$download_success) {
-				print "Error: Failed to download $filename from third-party URL $third_party_url\n";
-				exit 1;
-			}
-			$sha_verified = 0;  # Reset flag - must verify SHA for third-party download
-		}
-
-		# Verify SHA for third-party download or if not yet verified
 		# If shaurl is provided, download the sha file to get the expected checksum
 		# as the dependent third party jar may have been newly downloaded
-		if (!$ignoreChecksum && !$sha_verified) {
+		if (!$ignoreChecksum) {
 			if ($shaurl) {
 				downloadFile($shaurl, $shafn);
 				$expectedsha = getShaFromFile($shafn, $fn);
@@ -842,8 +793,6 @@ if ($task eq "clean") {
 				print "Please delete $filename and rerun the program!";
 				die "ERROR: sha checksum error.\n";
 			}
-		} elsif ($ignoreChecksum) {
-			print "Checksum verification skipped for $filename\n";
 		}
 	}
 	print "downloaded dependent third party jars successfully\n";

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -603,7 +603,8 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/ow2/asm/asm/9.0/asm-9.0.jar',
 		dir => 'asm',
 		fname => 'asm.jar',
-		sha1 => 'af582ff60bc567c42d931500c3fdc20e0141ddf9',
+		sha1 => '0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	cvsclient => {
@@ -650,7 +651,8 @@ my %system_jars = (
 		url => 'https://github.com/adoptium/aqa-triage-data/raw/main/AQAvit/mauve.jar',
 		dir => 'mauve',
 		fname => 'mauve.jar',
-		sha1 => 'f396c75df02c008aff745ebbff234856e0788732',
+		sha1 => '3272a712acef69936abaac6357f1d7a4296f1798efdb72658ca77c41e082da8e',
+		shaalg => '256',
 		is_system_test => 1
 	},
 	tools => {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -59,7 +59,8 @@ print "dependencyList is set to $dependencyList\n";
 # Contents in the hash should be:
 #   url - required. url to download the dependent jar
 #   fname - required. the dependent jar name
-#   sha1 - sha1 value for the dependent jar (can be skipped if both shaurl and shafn are provided)
+#   sha1 - optional. legacy sha1 value for the dependent jar
+#   sha256 - optional. sha256 value for the dependent jar
 #   shaurl - optional. url to download the sha file
 #   shafn  - optional. sha file name (has to be used with shaurl)
 #   shaalg - optional. sha is calculated based on shaalg (default value is sha1)
@@ -595,7 +596,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar',
 		dir => 'apache-ant/lib',
 		fname => 'ant-launcher.jar',
-		sha1 => '28cfb70020dfdb9e4e261ceed16c43aed715c1d11390e3ddbecda1e548253168',
+		sha256 => '28cfb70020dfdb9e4e261ceed16c43aed715c1d11390e3ddbecda1e548253168',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -603,7 +604,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/ow2/asm/asm/9.0/asm-9.0.jar',
 		dir => 'asm',
 		fname => 'asm.jar',
-		sha1 => '0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0',
+		sha256 => '0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -611,7 +612,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/netbeans/lib/cvsclient/20060125/cvsclient-20060125.jar',
 		dir => 'cvsclient',
 		fname => 'org-netbeans-lib-cvsclient.jar',
-		sha1 => '89baed753b393d5074d4b9b4ba4b9692af6cd0713199998fb294b99942c820a3',
+		sha256 => '89baed753b393d5074d4b9b4ba4b9692af6cd0713199998fb294b99942c820a3',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -619,7 +620,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar',
 		dir => 'junit',
 		fname => 'hamcrest-core.jar',
-		sha1 => '66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',
+		sha256 => '66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -627,7 +628,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar',
 		dir => 'junit',
 		fname => 'junit.jar',
-		sha1 => '59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
+		sha256 => '59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -635,7 +636,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-api.jar',
-		sha1 => 'c8c33e7e8e05496dae69cf0caac8c3092cffd937a164526e92922d2d566d0a55',
+		sha256 => 'c8c33e7e8e05496dae69cf0caac8c3092cffd937a164526e92922d2d566d0a55',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -643,7 +644,7 @@ my %system_jars = (
 		url => 'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar',
 		dir => 'log4j',
 		fname => 'log4j-core.jar',
-		sha1 => '419a8512895971b7b4f4f33e620d361254e5c9552b904b0474b09ddd4a6a220b',
+		sha256 => '419a8512895971b7b4f4f33e620d361254e5c9552b904b0474b09ddd4a6a220b',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -651,7 +652,7 @@ my %system_jars = (
 		url => 'https://github.com/adoptium/aqa-triage-data/raw/main/AQAvit/mauve.jar',
 		dir => 'mauve',
 		fname => 'mauve.jar',
-		sha1 => '3272a712acef69936abaac6357f1d7a4296f1798efdb72658ca77c41e082da8e',
+		sha256 => '3272a712acef69936abaac6357f1d7a4296f1798efdb72658ca77c41e082da8e',
 		shaalg => '256',
 		is_system_test => 1
 	},
@@ -693,7 +694,7 @@ if ($task eq "clean") {
 	for my $i (0 .. $#jars_info) {
 		my $url = $jars_info[$i]{url};
 		my $fn = $jars_info[$i]{fname};
-		my $sha1 = $jars_info[$i]{sha1};
+		my $checksum = $jars_info[$i]{sha256} // $jars_info[$i]{sha1};
 		my $dir = $jars_info[$i]{dir} // "";
 		my $full_dir_path = File::Spec->catdir($path, $dir);
 		if (exists($ENV{"BUILD_TYPE"}) && $ENV{"BUILD_TYPE"} eq "systemtest") {
@@ -743,7 +744,7 @@ if ($task eq "clean") {
 			$digest = $sha->hexdigest;
 		}
 
-		my $expectedsha = $jars_info[$i]{sha1};
+		my $expectedsha = $jars_info[$i]{sha256} // $jars_info[$i]{sha1};
 		if (!$expectedsha) {
 			if (defined $shafn && $shafn ne '') {
 				$shafn = $path . $sep . $shafn;
@@ -752,6 +753,13 @@ if ($task eq "clean") {
 					$expectedsha = getShaFromFile($shafn, $fn);
 				}
 			}
+
+			# if expectedsha is not set above and shaurl is provided, download the sha file
+			# and parse the file to get the expected sha so an existing valid file can be reused
+			if (!$expectedsha && $shaurl) {
+				downloadFile($shaurl, $shafn);
+				$expectedsha = getShaFromFile($shafn, $fn);
+			}
 		}
 
 		if ($expectedsha && $digest eq $expectedsha) {
@@ -759,7 +767,7 @@ if ($task eq "clean") {
 			next;
 		}
 
-		my $ignoreChecksum = (!defined $sha1 || $sha1 eq '') && (!defined $shaurl || $shaurl eq '');
+		my $ignoreChecksum = (!defined $checksum || $checksum eq '') && (!defined $shaurl || $shaurl eq '');
 
 		if ($ignoreChecksum && -e $filename) {
 			print "$filename exists, not downloading.\n";

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -704,6 +704,7 @@ if ($task eq "clean") {
 			}
 		}
 		my $url_testDependency = $testDependencyUrl;
+		my $third_party_url = $url;
 
 		if (!-d $full_dir_path) {
 			make_path($full_dir_path, {chmod => 0755, verbose => 1}) or die "Failed to create directory: $full_dir_path: $!";
@@ -720,6 +721,7 @@ if ($task eq "clean") {
 				$url_testDependency =~ s/test.getDependency/systemtest.getDependency/;
 				$url_testDependency .= "systemtest_prereqs/";
 				$url_testDependency .= $jars_info[$i]{dir};
+				$url_testDependency .= '/' unless $url_testDependency =~ /\/$/;
 			}
 
 			$url = "$url_testDependency/$jars_info[$i]{fname}";
@@ -752,24 +754,71 @@ if ($task eq "clean") {
 			}
 		}
 
-		my $ignoreChecksum = (!defined $sha1 || $sha1 eq '') && (!defined $shaurl || $shaurl eq '');
-
-		# If file exists and SHA matches, skip download entirely.
-		# If no checksum is available and the file is present, skip download.
-		if (-e $filename && $expectedsha && $digest eq $expectedsha) {
+		if ($expectedsha && $digest eq $expectedsha) {
 			print "$filename exists with correct hash, not downloading\n";
 			next;
 		}
+
+		my $ignoreChecksum = (!defined $sha1 || $sha1 eq '') && (!defined $shaurl || $shaurl eq '');
+
 		if ($ignoreChecksum && -e $filename) {
 			print "$filename exists, not downloading.\n";
 			next;
 		}
 
-		downloadFile($url, $filename);
+		my $download_success = 0;
+		my $sha_verified = 0;
+		my $has_testDependency_url = ($url_testDependency ne "" && $url ne $third_party_url);
+
+		# Try download from testDependency URL or third-party URL
+		eval {
+			downloadFile($url, $filename);
+			$download_success = 1;
+		};
+
+		# If download succeeded, verify SHA
+		if ($download_success && !$ignoreChecksum) {
+			my $expectedsha_check = $expectedsha;
+			if (!$expectedsha_check && $shaurl) {
+				eval {
+					downloadFile($shaurl, $shafn);
+					$expectedsha_check = getShaFromFile($shafn, $fn);
+				};
+			}
+
+			if ($expectedsha_check) {
+				$sha = Digest::SHA->new($shaalg);
+				$sha->addfile($filename);
+				$digest = $sha->hexdigest;
+				if ($digest eq $expectedsha_check) {
+					$sha_verified = 1;
+					print "SHA verification passed for $filename\n";
+				} elsif ($has_testDependency_url) {
+					print "Warning: SHA mismatch for $filename from testDependency URL\n";
+					print "Expected: $expectedsha_check, Got: $digest\n";
+					$download_success = 0;  # Mark as failed to trigger fallback
+					unlink $filename;  # Delete bad file
+				}
+			}
+		}
+
+		# Fall back to third-party URL if testDependency URL failed or had SHA mismatch
+		if (!$download_success) {
+			print "Falling back to third-party URL: $third_party_url\n";
+			eval {
+				downloadFile($third_party_url, $filename);
+				$download_success = 1;
+			};
+			if (!$download_success) {
+				print "Error: Failed to download $filename from third-party URL $third_party_url\n";
+				exit 1;
+			}
+			$sha_verified = 0;  # Reset flag - must verify SHA for third-party download
+		}
 
 		# If shaurl is provided, download the sha file to get the expected checksum
 		# as the dependent third party jar may have been newly downloaded
-		if (!$ignoreChecksum) {
+		if (!$ignoreChecksum && !$sha_verified) {
 			if ($shaurl) {
 				downloadFile($shaurl, $shafn);
 				$expectedsha = getShaFromFile($shafn, $fn);


### PR DESCRIPTION
### Summary
This PR completes the issue adoptium/TKG#561 fix in scripts/getDependencies.pl for system test prerequisite jars.

### What changed
Added/fixed checksum metadata for the affected is_system_test jars.
Migrated the updated SHA-256-backed entries to use sha256 => ... instead of storing SHA-256 values under sha1.
Kept backward compatibility by allowing checksum lookup to use either:
sha256
legacy sha1
Restored pre-download shaurl resolution so valid existing cached artifacts can still be reused when the expected checksum is provided via checksum sidecar rather than embedded metadata.
Why
Previously, several system test prerequisite jars were missing usable pinned checksum metadata, which prevented consistent cache-hit behavior and caused unnecessary re-downloads.

**This PR ensures that:**
the affected system jars use the correct pinned SHA-256 values,
checksum naming matches the actual digest type for the updated entries,
legacy checksum entries still continue to work,
and the expected checksum can still be resolved early enough to preserve warm-run cache reuse for shaurl-based dependencies.
